### PR TITLE
Improve PO translation pipeline formatting

### DIFF
--- a/examples/po_translation_example.py
+++ b/examples/po_translation_example.py
@@ -20,8 +20,7 @@ from marovi.modules.parsing.po_parser import POParser
 
 # Configure logging
 logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger(__name__)
 
@@ -29,23 +28,23 @@ logger = logging.getLogger(__name__)
 def chunk_markdown_text(text, max_chunk_size=800):
     """
     Split markdown text into manageable chunks for translation.
-    
+
     Args:
         text: Markdown text to split
         max_chunk_size: Maximum chunk size in characters
-        
+
     Returns:
         List of text chunks
     """
     if len(text) <= max_chunk_size:
         return [text]
-    
+
     # Try to split at paragraphs first
-    paragraphs = re.split(r'\n\n+', text)
-    
+    paragraphs = re.split(r"\n\n+", text)
+
     chunks = []
     current_chunk = ""
-    
+
     for paragraph in paragraphs:
         # If adding this paragraph would exceed the max size, start a new chunk
         if len(current_chunk) + len(paragraph) > max_chunk_size and current_chunk:
@@ -56,11 +55,11 @@ def chunk_markdown_text(text, max_chunk_size=800):
                 current_chunk += "\n\n" + paragraph
             else:
                 current_chunk = paragraph
-    
+
     # Add the last chunk if not empty
     if current_chunk:
         chunks.append(current_chunk)
-    
+
     # If we still have chunks that are too large, split them at sentences
     final_chunks = []
     for chunk in chunks:
@@ -68,57 +67,68 @@ def chunk_markdown_text(text, max_chunk_size=800):
             final_chunks.append(chunk)
         else:
             # Split at logical sentence boundaries
-            sentences = re.split(r'([.!?]\s+)', chunk)
+            sentences = re.split(r"([.!?]\s+)", chunk)
             current_chunk = ""
-            
+
             # Join sentences back with their punctuation
             i = 0
             while i < len(sentences) - 1:
-                sentence = sentences[i] + sentences[i+1] if i+1 < len(sentences) else sentences[i]
+                sentence = (
+                    sentences[i] + sentences[i + 1]
+                    if i + 1 < len(sentences)
+                    else sentences[i]
+                )
                 i += 2
-                
-                if len(current_chunk) + len(sentence) > max_chunk_size and current_chunk:
+
+                if (
+                    len(current_chunk) + len(sentence) > max_chunk_size
+                    and current_chunk
+                ):
                     final_chunks.append(current_chunk)
                     current_chunk = sentence
                 else:
                     current_chunk += sentence
-            
+
             # Add the last chunk
             if current_chunk:
                 final_chunks.append(current_chunk)
-    
+
     return final_chunks
 
 
 def translate_large_text(text, source_lang, target_lang, translator_type, api_client):
     """
     Translate large text by chunking it into smaller parts.
-    
+
     Args:
         text: Text to translate
         source_lang: Source language code
         target_lang: Target language code
         translator_type: Type of translator ('google' or 'llm')
         api_client: MaroviAPI client instance
-        
+
     Returns:
         Translated text
     """
     # If text is not that large, translate directly
     if len(text) < 1000:
-        return translate_text(text, source_lang, target_lang, translator_type, api_client)
-    
+        return translate_text(
+            text, source_lang, target_lang, translator_type, api_client
+        )
+
     # Chunk the text
     chunks = chunk_markdown_text(text)
     logger.info(f"Split large text into {len(chunks)} chunks for translation")
-    
+
     # Translate each chunk
     translated_chunks = []
     for i, chunk in enumerate(chunks):
         logger.debug(f"Translating chunk {i+1}/{len(chunks)} ({len(chunk)} chars)")
-        translated_chunk = translate_text(chunk, source_lang, target_lang, translator_type, api_client)
+        translated_chunk = translate_text(
+            chunk, source_lang, target_lang, translator_type, api_client
+        )
         translated_chunks.append(translated_chunk)
-    
+
     # Join the translated chunks
     return "\n\n".join(translated_chunks)
 
@@ -126,14 +136,14 @@ def translate_large_text(text, source_lang, target_lang, translator_type, api_cl
 def translate_text(text, source_lang, target_lang, translator_type, api_client):
     """
     Translate a single text using the specified translator.
-    
+
     Args:
         text: Text to translate
         source_lang: Source language code
         target_lang: Target language code
         translator_type: Type of translator ('google' or 'llm')
         api_client: MaroviAPI client instance
-        
+
     Returns:
         Translated text
     """
@@ -143,14 +153,14 @@ def translate_text(text, source_lang, target_lang, translator_type, api_client):
                 text=text,
                 source_lang=source_lang,
                 target_lang=target_lang,
-                provider="google"
+                provider="google",
             )
         else:  # LLM translation
             response = api_client.custom.llm_translate(
                 text=text,
                 source_lang=source_lang,
                 target_lang=target_lang,
-                provider="openai"
+                provider="openai",
             )
             return response.get("translated_text", "")
     except Exception as e:
@@ -166,11 +176,11 @@ def translate_po_file(
     target_lang: str = "es",
     translator_type: str = "google",
     include_translated: bool = False,
-    api_client = None
+    api_client=None,
 ) -> bool:
     """
     Translate a PO file using either Google Translate or LLM.
-    
+
     Args:
         input_path: Path to input PO file
         output_path: Path to save translated PO file
@@ -179,7 +189,7 @@ def translate_po_file(
         translator_type: Type of translator ('google' or 'llm')
         include_translated: Whether to include already translated entries
         api_client: Optional MaroviAPI client instance
-        
+
     Returns:
         True if successful, False otherwise
     """
@@ -187,13 +197,13 @@ def translate_po_file(
         # Initialize API client if not provided
         if api_client is None:
             api_client = MaroviAPI()
-        
+
         # Initialize parser
         parser = POParser()
-        
+
         logger.info(f"Loading PO file: {input_path}")
         parser.load_from_file(input_path, include_translated=include_translated)
-        
+
         # Get messages to translate
         messages = parser.get_messages()
         if not messages:
@@ -201,34 +211,38 @@ def translate_po_file(
             # Save the file anyway as a copy
             parser.save_translated_po(output_path, [])
             return True
-        
+
         logger.info(f"Found {len(messages)} messages to translate")
-        
+
         # Extract source texts
         texts_to_translate = [msg[0] for msg in messages]
-        
+
         # Set translator type
         translator_type = translator_type.lower()
         if translator_type not in ["google", "llm"]:
             logger.warning(f"Unknown translator type: {translator_type}. Using Google.")
             translator_type = "google"
-        
+
         # Translate texts
-        logger.info(f"Translating {len(texts_to_translate)} messages from {source_lang} to {target_lang} using {translator_type}")
+        logger.info(
+            f"Translating {len(texts_to_translate)} messages from {source_lang} to {target_lang} using {translator_type}"
+        )
         translated_texts = []
-        
+
         for i, text in enumerate(texts_to_translate):
             try:
                 # Check if this is likely to be Markdown or Wiki content
-                is_large_content = len(text) > 1000 or '[[' in text or '==' in text or '\n\n' in text
-                
+                is_large_content = (
+                    len(text) > 1000 or "[[" in text or "==" in text or "\n\n" in text
+                )
+
                 if is_large_content:
                     translated_text = translate_large_text(
                         text=text,
                         source_lang=source_lang,
                         target_lang=target_lang,
                         translator_type=translator_type,
-                        api_client=api_client
+                        api_client=api_client,
                     )
                 else:
                     translated_text = translate_text(
@@ -236,39 +250,42 @@ def translate_po_file(
                         source_lang=source_lang,
                         target_lang=target_lang,
                         translator_type=translator_type,
-                        api_client=api_client
+                        api_client=api_client,
                     )
-                
+
                 translated_texts.append(translated_text)
                 logger.info(f"Translated message {i+1}/{len(texts_to_translate)}")
             except Exception as e:
                 logger.error(f"Error translating message {i+1}: {str(e)}")
                 # Fall back to source text if translation fails
                 translated_texts.append(text)
-        
+
         # Save translated PO file
         logger.info(f"Saving translations to: {output_path}")
         parser.save_translated_po(output_path, translated_texts)
-        
+
         # Display sample translations (up to 5)
         logger.info("Sample translations:")
         po = parser.po_file
         for i, entry in enumerate(po):
             if i < 5:  # Show only up to 5 translations
-                logger.info(f"  {entry.msgctxt or i}: '{entry.msgid[:50]}...' -> '{entry.msgstr[:50]}...'")
+                logger.info(
+                    f"  {entry.msgctxt or i}: '{entry.msgid[:50]}...' -> '{entry.msgstr[:50]}...'"
+                )
             else:
                 break
-                
+
         # Update PO file headers for target language
-        po.metadata['Language'] = target_lang
-        po.metadata['X-Language-Code'] = target_lang
-        
+        po.metadata["Language"] = target_lang
+        po.metadata["X-Language-Code"] = target_lang
+
         logger.info(f"Translation completed successfully. Saved to {output_path}")
         return True
-    
+
     except Exception as e:
         logger.error(f"Translation failed: {str(e)}")
         import traceback
+
         traceback.print_exc()
         return False
 
@@ -276,57 +293,53 @@ def translate_po_file(
 def create_sample_po_file(output_path: str = None):
     """
     Create a sample PO file with content for demonstration purposes.
-    
+
     Args:
         output_path: Path to save the sample file (if None, a temp file is created)
-        
+
     Returns:
         Path to the created PO file
     """
     import polib
-    
+
     # Create a POFile object
     po = polib.POFile()
     po.metadata = {
-        'Project-Id-Version': 'Sample PO File',
-        'Language': 'en',
-        'MIME-Version': '1.0',
-        'Content-Type': 'text/plain; charset=utf-8',
-        'Content-Transfer-Encoding': '8bit',
+        "Project-Id-Version": "Sample PO File",
+        "Language": "en",
+        "MIME-Version": "1.0",
+        "Content-Type": "text/plain; charset=utf-8",
+        "Content-Transfer-Encoding": "8bit",
     }
-    
+
     # Add sample entries
     entries = [
-        polib.POEntry(
-            msgid="Hello, world!",
-            msgstr="",
-            msgctxt="greeting"
-        ),
+        polib.POEntry(msgid="Hello, world!", msgstr="", msgctxt="greeting"),
         polib.POEntry(
             msgid="Welcome to the Marovi AI translation system.",
             msgstr="",
-            msgctxt="welcome"
+            msgctxt="welcome",
         ),
         polib.POEntry(
             msgid="This text will be translated by an AI system.",
             msgstr="",
-            msgctxt="explanation"
+            msgctxt="explanation",
         ),
         polib.POEntry(
             msgid="Different translators may produce different results.",
             msgstr="",
-            msgctxt="comparison"
+            msgctxt="comparison",
         ),
         polib.POEntry(
             msgid="Please provide feedback on translation quality.",
             msgstr="",
-            msgctxt="feedback"
-        )
+            msgctxt="feedback",
+        ),
     ]
-    
+
     for entry in entries:
         po.append(entry)
-    
+
     # Add a large markdown entry for chunking demonstration
     large_markdown = """
 # Markdown Translation Example
@@ -365,42 +378,51 @@ Markdown is widely used for:
 
 It's particularly useful for content that needs to be readable in plain text format but can also be converted to rich text when needed.
 """
-    
-    po.append(polib.POEntry(
-        msgid=large_markdown,
-        msgstr="",
-        msgctxt="markdown_sample"
-    ))
-    
+
+    po.append(polib.POEntry(msgid=large_markdown, msgstr="", msgctxt="markdown_sample"))
+
     # Determine output path
     if output_path is None:
         temp_dir = tempfile.mkdtemp()
         output_path = os.path.join(temp_dir, "sample_en.po")
-    
+
     # Save the file
     po.save(output_path)
     logger.info(f"Created sample PO file at {output_path}")
-    
+
     return output_path
 
 
 def main():
     """Run the PO translation example."""
     parser = argparse.ArgumentParser(description="PO Translation Example")
-    parser.add_argument("--input", help="Input PO file path (if not provided, creates a sample file)")
+    parser.add_argument(
+        "--input", help="Input PO file path (if not provided, creates a sample file)"
+    )
     parser.add_argument("--output", help="Output directory for translated files")
-    parser.add_argument("--source", default="en", help="Source language code (default: en)")
-    parser.add_argument("--target", default="es", help="Target language code (default: es)")
-    parser.add_argument("--translator", default="google", choices=["google", "llm"], 
-                        help="Translator type to use (default: google)")
-    parser.add_argument("--include-translated", action="store_true", 
-                        help="Include already translated entries (default: False)")
-    
+    parser.add_argument(
+        "--source", default="en", help="Source language code (default: en)"
+    )
+    parser.add_argument(
+        "--target", default="es", help="Target language code (default: es)"
+    )
+    parser.add_argument(
+        "--translator",
+        default="google",
+        choices=["google", "llm"],
+        help="Translator type to use (default: google)",
+    )
+    parser.add_argument(
+        "--include-translated",
+        action="store_true",
+        help="Include already translated entries (default: False)",
+    )
+
     args = parser.parse_args()
-    
+
     # Initialize API client (reused for multiple translations)
     api_client = MaroviAPI()
-    
+
     # Handle input file
     input_path = args.input
     if not input_path:
@@ -409,7 +431,7 @@ def main():
     elif not os.path.exists(input_path):
         logger.error(f"Input file not found: {input_path}")
         return 1
-    
+
     # Determine output path
     if args.output:
         os.makedirs(args.output, exist_ok=True)
@@ -419,7 +441,7 @@ def main():
         output_dir = os.path.dirname(input_path)
         output_filename = f"{Path(input_path).stem}_{args.target}.po"
         output_path = os.path.join(output_dir, output_filename)
-    
+
     # Translate the file
     success = translate_po_file(
         input_path=input_path,
@@ -428,9 +450,9 @@ def main():
         target_lang=args.target,
         translator_type=args.translator,
         include_translated=args.include_translated,
-        api_client=api_client
+        api_client=api_client,
     )
-    
+
     if success:
         logger.info("Example completed successfully")
         return 0
@@ -440,4 +462,4 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.exit(main()) 
+    sys.exit(main())

--- a/marovi/api/custom/endpoints/llm_translate.py
+++ b/marovi/api/custom/endpoints/llm_translate.py
@@ -23,20 +23,26 @@ import time
 # Configure logging
 logger = logging.getLogger(__name__)
 
+
 # Define a TranslationError exception
 class TranslationError(Exception):
     """Exception raised when translation fails."""
+
     pass
+
 
 class TranslationRequest(BaseModel):
     """Request model for translation."""
+
     text: str
     source_lang: str
     target_lang: str
     options: Optional[Dict[str, Any]] = None
 
+
 class TranslationResponse(BaseModel):
     """Response model for translation."""
+
     content: str
     source_lang: str
     target_lang: str
@@ -45,83 +51,88 @@ class TranslationResponse(BaseModel):
     latency: float = Field(default=0.0)
     format: str = Field(default="text")
 
+
 class LLMTranslate(CustomEndpoint):
     """
     Translation service that uses LLMs for translation.
-    
+
     This endpoint provides translation services using LLM models instead of
     traditional translation APIs. It follows the same interface as the
     standard translation endpoints for consistency.
     """
-    
+
     def __init__(self, llm_client=None):
         """Initialize the LLM translator."""
         self.request_model = TranslationRequest
         self.response_model = TranslationResponse
         self.llm_client = llm_client
-    
-    def __call__(self, text: str, source_lang: str, target_lang: str, **kwargs) -> Dict[str, Any]:
+
+    def __call__(
+        self, text: str, source_lang: str, target_lang: str, **kwargs
+    ) -> Dict[str, Any]:
         """
         Translate text using an LLM.
-        
+
         Args:
             text: Text to translate
             source_lang: Source language code
             target_lang: Target language code
             **kwargs: Additional parameters like model, instruction, temperature
-            
+
         Returns:
             JSON response with translated text and metadata
         """
         result = self.translate(text, source_lang, target_lang, **kwargs)
         return result
-    
+
     def _get_llm_client(self):
         """
         Get the LLM client, either the one provided in the constructor or from the router.
-        
+
         Returns:
             LLM client instance
         """
         if self.llm_client:
             return self.llm_client
-            
+
         # Get the default LLM client from the router
         try:
             # Lazy import to avoid circular dependencies
             from ...core.router import default_router
             from ...core.base import ServiceType
-            
+
             # Get the default LLM client
             llm_client = default_router.get_service(ServiceType.LLM)
             logger.info("Using default LLM client from router")
             return llm_client
         except Exception as e:
             logger.error(f"Failed to get default LLM client: {str(e)}")
-            raise ValueError("No LLM client provided and could not get default client from router")
-    
+            raise ValueError(
+                "No LLM client provided and could not get default client from router"
+            )
+
     def process(self, request: TranslationRequest) -> TranslationResponse:
         """
         Process a translation request.
-        
+
         Args:
             request: Translation request
-            
+
         Returns:
             Translation response
         """
         start_time = time.time()
-        
+
         try:
             # Get the LLM client
             llm_client = self._get_llm_client()
-            
+
             # Extract parameters from request
             text = request.text
             source_lang = request.source_lang
             target_lang = request.target_lang
             options = request.options or {}
-            
+
             # Create prompt for the LLM
             prompt = f"""
             Translate the following text from {source_lang} to {target_lang}:
@@ -130,13 +141,13 @@ class LLMTranslate(CustomEndpoint):
             
             Only return the translated text, without any explanations or notes.
             """
-            
+
             # Call the LLM
             translated_text = llm_client.complete(prompt).strip()
-            
+
             # Calculate latency
             latency = time.time() - start_time
-            
+
             # Create and return response
             return TranslationResponse(
                 content=translated_text,
@@ -144,41 +155,47 @@ class LLMTranslate(CustomEndpoint):
                 target_lang=target_lang,
                 success=True,
                 latency=latency,
-                format="text"
+                format="text",
             )
         except Exception as e:
             latency = time.time() - start_time
             logger.error(f"Translation failed: {str(e)}")
             return TranslationResponse(
                 content="",
-                source_lang=request.source_lang, 
+                source_lang=request.source_lang,
                 target_lang=request.target_lang,
                 success=False,
                 error=str(e),
                 latency=latency,
-                format="text"
+                format="text",
             )
-    
-    def translate(self, text: str, source_lang: str, target_lang: str, 
-                provider: Optional[str] = None, **kwargs) -> Dict[str, Any]:
+
+    def translate(
+        self,
+        text: str,
+        source_lang: str,
+        target_lang: str,
+        provider: Optional[str] = None,
+        **kwargs,
+    ) -> Dict[str, Any]:
         """
         Translate text using an LLM.
-        
+
         Args:
             text: Text to translate
             source_lang: Source language code
             target_lang: Target language code
             provider: Optional LLM provider to use (defaults to the router's default)
             **kwargs: Additional parameters like model, instruction, temperature
-            
+
         Returns:
             JSON response with translated text and metadata
         """
         start_time = time.time()
-        
+
         # Store the original LLM client
         original_llm_client = self.llm_client
-        
+
         try:
             # If provider is specified, get an LLM client for that provider
             if provider:
@@ -186,147 +203,159 @@ class LLMTranslate(CustomEndpoint):
                     # Lazy import to avoid circular dependencies
                     from ...core.router import default_router
                     from ...core.base import ServiceType
-                    
+
                     # Get the LLM client for the specified provider
-                    self.llm_client = default_router.get_service(ServiceType.LLM, provider=provider)
+                    self.llm_client = default_router.get_service(
+                        ServiceType.LLM, provider=provider
+                    )
                     logger.info(f"Using specified LLM provider: {provider}")
                 except Exception as e:
-                    logger.warning(f"Could not use specified provider {provider}: {str(e)}. Using default.")
+                    logger.warning(
+                        f"Could not use specified provider {provider}: {str(e)}. Using default."
+                    )
                     # Ensure we have a default client
                     if not self.llm_client:
                         self.llm_client = self._get_llm_client()
             elif not self.llm_client:
                 # Get the default LLM client if not already set
                 self.llm_client = self._get_llm_client()
-                
+
             # Create a translation instruction
-            instruction = kwargs.get('instruction') or self._create_translation_instruction(source_lang, target_lang)
-            
+            instruction = kwargs.get(
+                "instruction"
+            ) or self._create_translation_instruction(source_lang, target_lang)
+
             # Ensure text is a string (handle list input if needed)
             if isinstance(text, list):
                 text = "\n".join([str(item) for item in text])
             elif not isinstance(text, str):
                 text = str(text)
-            
+
             # Use the provided LLM client to translate
             response = self.llm_client.complete(
                 instruction + "\n\n" + text,
-                temperature=kwargs.get('temperature', 0.1),
-                model=kwargs.get('model'),
-                max_tokens=kwargs.get('max_tokens', 4000)
+                temperature=kwargs.get("temperature", 0.1),
+                model=kwargs.get("model"),
+                max_tokens=kwargs.get("max_tokens", 4000),
             )
-            
+
             # Handle both string responses and LLMResponse objects
-            if hasattr(response, 'content'):
+            if hasattr(response, "content"):
                 translated_text = response.content.strip()
             else:
                 # Assume it's a string
                 translated_text = str(response).strip()
-            
+
             # Create a standardized response similar to other translation endpoints
             result = {
-                "provider": provider or getattr(self.llm_client, 'provider_type_str', 'llm'),
+                "provider": provider
+                or getattr(self.llm_client, "provider_type_str", "llm"),
                 "text": text,
                 "translated_text": translated_text,
                 "source_lang": source_lang,
                 "target_lang": target_lang,
                 "metadata": {
                     "latency": time.time() - start_time,
-                    "model": kwargs.get('model', getattr(self.llm_client, 'model', 'default')),
-                    "temperature": kwargs.get('temperature', 0.1),
-                }
+                    "model": kwargs.get(
+                        "model", getattr(self.llm_client, "model", "default")
+                    ),
+                    "temperature": kwargs.get("temperature", 0.1),
+                },
             }
-            
+
             return result
-            
+
         except Exception as e:
             # Log the error
             logger.error(f"LLM translation failed: {str(e)}")
-            
+
             # Raise a specific exception
             raise TranslationError(f"LLM translation failed: {str(e)}")
         finally:
             # Restore the original LLM client
             self.llm_client = original_llm_client
-    
-    def _create_translation_instruction(self, source_lang: str, target_lang: str) -> str:
+
+    def _create_translation_instruction(
+        self, source_lang: str, target_lang: str
+    ) -> str:
         """Create a translation instruction for the LLM."""
-        if source_lang == 'auto':
-            source_lang = 'the source language'
+        if source_lang == "auto":
+            source_lang = "the source language"
         else:
             source_lang = self._get_full_language_name(source_lang)
-            
+
         target_lang = self._get_full_language_name(target_lang)
-            
+
         return f"Translate the following text from {source_lang} to {target_lang}. Output only the translated text, with no explanations or notes."
-    
+
     def get_capabilities(self) -> List[str]:
         """Get the capabilities of this translator."""
         return ["translation", "llm_translate"]
-    
+
     def get_metadata(self) -> Dict[str, Any]:
         """Get metadata about this translator."""
         return {
             "type": "translator",
             "provider": "llm",
             "supports_batch": False,
-            "uses_llm": True
+            "uses_llm": True,
         }
-    
+
     def _get_full_language_name(self, lang_code: str) -> str:
         """
         Convert a language code to a full language name.
-        
+
         Args:
             lang_code: ISO language code (e.g., 'en', 'fr')
-            
+
         Returns:
             Full language name (e.g., 'English', 'French')
         """
         # Common language codes to names mapping
         language_map = {
-            'en': 'English',
-            'es': 'Spanish',
-            'fr': 'French',
-            'de': 'German',
-            'it': 'Italian',
-            'pt': 'Portuguese',
-            'ru': 'Russian',
-            'zh': 'Chinese',
-            'ja': 'Japanese',
-            'ko': 'Korean',
-            'ar': 'Arabic',
-            'hi': 'Hindi',
-            'bn': 'Bengali',
-            'nl': 'Dutch',
-            'pl': 'Polish',
-            'sv': 'Swedish',
-            'fi': 'Finnish',
-            'no': 'Norwegian',
-            'da': 'Danish',
-            'tr': 'Turkish',
-            'el': 'Greek',
-            'he': 'Hebrew',
-            'th': 'Thai',
-            'vi': 'Vietnamese',
-            'cs': 'Czech',
-            'hu': 'Hungarian',
-            'ro': 'Romanian',
-            'uk': 'Ukrainian',
-            'auto': 'Auto-detected language'
+            "en": "English",
+            "es": "Spanish",
+            "fr": "French",
+            "de": "German",
+            "it": "Italian",
+            "pt": "Portuguese",
+            "ru": "Russian",
+            "zh": "Chinese",
+            "ja": "Japanese",
+            "ko": "Korean",
+            "ar": "Arabic",
+            "hi": "Hindi",
+            "bn": "Bengali",
+            "nl": "Dutch",
+            "pl": "Polish",
+            "sv": "Swedish",
+            "fi": "Finnish",
+            "no": "Norwegian",
+            "da": "Danish",
+            "tr": "Turkish",
+            "el": "Greek",
+            "he": "Hebrew",
+            "th": "Thai",
+            "vi": "Vietnamese",
+            "cs": "Czech",
+            "hu": "Hungarian",
+            "ro": "Romanian",
+            "uk": "Ukrainian",
+            "auto": "Auto-detected language",
         }
-        
+
         # Return the full name if found, otherwise use the code
-        return language_map.get(lang_code.lower(), lang_code) 
+        return language_map.get(lang_code.lower(), lang_code)
+
 
 def create_llm_translate(llm_client=None, **kwargs):
     """
     Factory function to create an LLMTranslate instance.
-    
+
     Args:
         llm_client: Optional LlmClient instance to use
         **kwargs: Additional keyword arguments to pass to LLMTranslate constructor
-        
+
     Returns:
         LLMTranslate instance
     """

--- a/marovi/modules/parsing/po_parser.py
+++ b/marovi/modules/parsing/po_parser.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from marovi.modules.parsing.base_parser import BaseParser
 from marovi.config import LANGUAGES
 
+
 class POParser(BaseParser):
     """
     Parser for .po translation files that handles message IDs and strings.
@@ -14,7 +15,7 @@ class POParser(BaseParser):
     def __init__(self, content: str = ""):
         """
         Initialize the parser.
-        
+
         Args:
             content (str): Optional raw content of a PO file.
         """
@@ -23,47 +24,56 @@ class POParser(BaseParser):
         self.entries: List[polib.POEntry] = []
         self.source_language: str = "en"
         self.target_language: str = ""
-        
+
         # Initialize from content if provided
         if content:
             self.po_file = polib.pofile(content)
-            self.entries = [entry for entry in self.po_file 
-                          if not entry.obsolete and entry.msgid.strip()]
+            self.entries = [
+                entry
+                for entry in self.po_file
+                if not entry.obsolete and entry.msgid.strip()
+            ]
 
     def load_from_file(self, file_path: str, include_translated: bool = False):
         """
         Load PO content from a file.
-        
+
         Args:
             file_path: Path to PO file
             include_translated: If True, include already translated entries
         """
         self.po_file = polib.pofile(file_path)
         if include_translated:
-            self.entries = [entry for entry in self.po_file 
-                          if not entry.obsolete and entry.msgid.strip()]
+            self.entries = [
+                entry
+                for entry in self.po_file
+                if not entry.obsolete and entry.msgid.strip()
+            ]
         else:
-            self.entries = [entry for entry in self.po_file.untranslated_entries() 
-                          if not entry.obsolete and entry.msgid.strip()]
-        
+            self.entries = [
+                entry
+                for entry in self.po_file.untranslated_entries()
+                if not entry.obsolete and entry.msgid.strip()
+            ]
+
         super().load_from_file(file_path)
 
     def parse(self) -> Dict[str, str]:
         """
         Parse the PO file and return a dictionary of message IDs and their content.
-        
+
         Returns:
             Dict[str, str]: Dictionary mapping message IDs to message strings
         """
         if not self.po_file:
             return {}
-        
+
         return {entry.msgid: entry.msgstr for entry in self.entries}
 
     def get_messages(self) -> List[Tuple[str, str]]:
         """
         Get pairs of message IDs and their content.
-        
+
         Returns:
             List of (msgid, msgstr) tuples for untranslated entries
         """
@@ -74,7 +84,7 @@ class POParser(BaseParser):
     def get_messages_with_translations(self) -> List[Tuple[str, str, str]]:
         """
         Get triples of message IDs, their content, and existing translations.
-        
+
         Returns:
             List of (msgid, msgstr, existing_translation) tuples
         """
@@ -85,7 +95,7 @@ class POParser(BaseParser):
     def save_translated_po(self, output_file: str, translations: List[str]):
         """
         Save PO file with translations added.
-        
+
         Args:
             output_file: Path to output PO file
             translations: List of translated texts
@@ -94,15 +104,17 @@ class POParser(BaseParser):
         if not self.entries:
             self.po_file.save(output_file)
             return
-            
+
         # If there are entries but no translations, treat as a copy operation
         if not translations:
             self.po_file.save(output_file)
             return
-            
+
         # Validate matching lengths only if both are non-empty
         if translations and self.entries and len(translations) != len(self.entries):
-            raise ValueError(f"Number of translations ({len(translations)}) must match number of entries ({len(self.entries)})")
+            raise ValueError(
+                f"Number of translations ({len(translations)}) must match number of entries ({len(self.entries)})"
+            )
 
         # Update translations in the PO file
         for entry, translation in zip(self.entries, translations):
@@ -114,52 +126,56 @@ class POParser(BaseParser):
     def compile_translations(self, include_msgids: bool = False) -> str:
         """
         Compile all translations into a single document.
-        
+
         Args:
             include_msgids: If True, include message IDs as headers before translations
-            
+
         Returns:
             str: Combined translations with newlines between entries
         """
         if not self.po_file:
             raise ValueError("No PO file loaded")
-            
+
         translations = []
         for entry in self.po_file:
             if entry.msgstr.strip():  # Only include non-empty translations
                 if include_msgids:
                     translations.append(f"# {entry.msgid}")
                 translations.append(entry.msgstr)
-            
+
         return "\n\n".join(translations)
-    
+
     def set_languages(self, source_language: str = "en", target_language: str = ""):
         """
         Set source and target languages for translation.
-        
+
         Args:
             source_language: Source language code (e.g., 'en')
             target_language: Target language code (e.g., 'es')
         """
         if source_language not in LANGUAGES:
-            raise ValueError(f"Source language {source_language} not supported. Available: {LANGUAGES}")
-        
+            raise ValueError(
+                f"Source language {source_language} not supported. Available: {LANGUAGES}"
+            )
+
         if target_language and target_language not in LANGUAGES:
-            raise ValueError(f"Target language {target_language} not supported. Available: {LANGUAGES}")
-        
+            raise ValueError(
+                f"Target language {target_language} not supported. Available: {LANGUAGES}"
+            )
+
         self.source_language = source_language
         self.target_language = target_language
-    
+
     def auto_translate(self, translation_service: Any) -> List[str]:
         """
         Automatically translate all untranslated entries using a translation service.
-        
+
         Args:
             translation_service: An object that provides translation functionality
-            
+
         Returns:
             List[str]: List of translated strings
-            
+
         Note:
             translation_service should have a translate method that accepts:
             - text: str or List[str] - text to translate
@@ -168,42 +184,42 @@ class POParser(BaseParser):
         """
         if not self.target_language:
             raise ValueError("Target language not set. Call set_languages() first.")
-        
+
         if not self.entries:
             return []
-        
+
         texts_to_translate = [entry.msgid for entry in self.entries]
-        
+
         # Perform batch translation
         try:
             translated_texts = translation_service.translate(
                 text=texts_to_translate,
                 source_language=self.source_language,
-                target_language=self.target_language
+                target_language=self.target_language,
             )
-            
+
             # Update entries with translations
             for entry, translation in zip(self.entries, translated_texts):
                 entry.msgstr = translation
-                
+
             return translated_texts
-            
+
         except Exception as e:
             raise Exception(f"Translation failed: {e}")
-    
+
     def get_stats(self) -> Dict[str, int]:
         """
         Get statistics about the PO file.
-        
+
         Returns:
             Dict[str, int]: Statistics including total entries, translated, and untranslated
         """
         if not self.po_file:
             return {"total": 0, "translated": 0, "untranslated": 0, "fuzzy": 0}
-        
+
         return {
             "total": len(self.po_file),
             "translated": len(self.po_file.translated_entries()),
             "untranslated": len(self.po_file.untranslated_entries()),
-            "fuzzy": len(self.po_file.fuzzy_entries())
-        } 
+            "fuzzy": len(self.po_file.fuzzy_entries()),
+        }

--- a/marovi/modules/steps/__init__.py
+++ b/marovi/modules/steps/__init__.py
@@ -7,7 +7,7 @@ This package provides various pipeline steps for document processing tasks.
 from marovi.modules.steps.parsing import (
     POFileParserStep,
     POFileWriterStep,
-    TranslationConnectorStep
+    TranslationConnectorStep,
 )
 
 from marovi.modules.steps.marovi_api import (
@@ -16,31 +16,29 @@ from marovi.modules.steps.marovi_api import (
     SummarizeStep,
     CompleteStep,
     ConvertFormatStep,
-    CleanTextStep
+    CleanTextStep,
 )
 
 from marovi.modules.steps.translation import (
     POFileTranslatorStep,
     POFileBatchTranslatorStep,
-    POFileWriterWithMultiLanguageSupport
+    POFileWriterWithMultiLanguageSupport,
 )
 
 __all__ = [
     # Parsing steps
-    'POFileParserStep',
-    'POFileWriterStep',
-    'TranslationConnectorStep',
-    
+    "POFileParserStep",
+    "POFileWriterStep",
+    "TranslationConnectorStep",
     # API steps
-    'TranslateStep',
-    'LLMTranslateStep',
-    'SummarizeStep',
-    'CompleteStep',
-    'ConvertFormatStep',
-    'CleanTextStep',
-    
+    "TranslateStep",
+    "LLMTranslateStep",
+    "SummarizeStep",
+    "CompleteStep",
+    "ConvertFormatStep",
+    "CleanTextStep",
     # Translation steps
-    'POFileTranslatorStep',
-    'POFileBatchTranslatorStep',
-    'POFileWriterWithMultiLanguageSupport'
+    "POFileTranslatorStep",
+    "POFileBatchTranslatorStep",
+    "POFileWriterWithMultiLanguageSupport",
 ]

--- a/marovi/modules/steps/marovi_api.py
+++ b/marovi/modules/steps/marovi_api.py
@@ -7,7 +7,18 @@ allowing seamless integration of MaroviAPI services into processing pipelines.
 
 import logging
 import inspect
-from typing import Any, Callable, Dict, List, Optional, Union, TypeVar, Generic, Type, get_args
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Union,
+    TypeVar,
+    Generic,
+    Type,
+    get_args,
+)
 
 from marovi.pipelines.core import PipelineStep
 from marovi.pipelines.context import PipelineContext
@@ -18,42 +29,47 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # Type variables
-InputType = TypeVar('InputType')
-OutputType = TypeVar('OutputType')
+InputType = TypeVar("InputType")
+OutputType = TypeVar("OutputType")
 
 __all__ = [
-    'MaroviAPIStep', 
-    'TranslateStep', 
-    'LLMTranslateStep', 
-    'SummarizeStep', 
-    'CompleteStep', 
-    'ConvertFormatStep',
-    'CleanTextStep'
+    "MaroviAPIStep",
+    "TranslateStep",
+    "LLMTranslateStep",
+    "SummarizeStep",
+    "CompleteStep",
+    "ConvertFormatStep",
+    "CleanTextStep",
 ]
 
-class MaroviAPIStep(PipelineStep[InputType, OutputType], Generic[InputType, OutputType]):
+
+class MaroviAPIStep(
+    PipelineStep[InputType, OutputType], Generic[InputType, OutputType]
+):
     """
     A dynamic pipeline step that wraps any MaroviAPI client endpoint.
-    
+
     This step allows seamless integration of any MaroviAPI service into a processing pipeline
     by dynamically dispatching to the appropriate client method based on the service and endpoint
-    parameters. It handles both single items and batches, automatically leveraging any batch or 
+    parameters. It handles both single items and batches, automatically leveraging any batch or
     async capabilities provided by the underlying API endpoints.
     """
-    
-    def __init__(self, 
-                 service: str,
-                 endpoint: str,
-                 client: Optional[MaroviAPI] = None,
-                 endpoint_kwargs: Optional[Dict[str, Any]] = None,
-                 input_field: str = "text",
-                 output_field: Optional[str] = None,
-                 batch_size: int = 10,
-                 process_mode: str = "parallel",
-                 step_id: Optional[str] = None):
+
+    def __init__(
+        self,
+        service: str,
+        endpoint: str,
+        client: Optional[MaroviAPI] = None,
+        endpoint_kwargs: Optional[Dict[str, Any]] = None,
+        input_field: str = "text",
+        output_field: Optional[str] = None,
+        batch_size: int = 10,
+        process_mode: str = "parallel",
+        step_id: Optional[str] = None,
+    ):
         """
         Initialize a MaroviAPI step.
-        
+
         Args:
             service: Service name in the MaroviAPI client (e.g., 'llm', 'translation', 'custom')
             endpoint: Method name in the service (e.g., 'complete', 'translate', 'summarize')
@@ -67,136 +83,164 @@ class MaroviAPIStep(PipelineStep[InputType, OutputType], Generic[InputType, Outp
         """
         super().__init__(
             batch_size=batch_size,
-            batch_handling='inherent',
+            batch_handling="inherent",
             process_mode=process_mode,
-            step_id=step_id or f"marovi_api_{service}_{endpoint}"
+            step_id=step_id or f"marovi_api_{service}_{endpoint}",
         )
-        
+
         self.service = service
         self.endpoint = endpoint
         self.client = client or MaroviAPI()
         self.endpoint_kwargs = endpoint_kwargs or {}
         self.input_field = input_field
         self.output_field = output_field
-        
+
         # Validate that the service and endpoint exist
         try:
             service_client = getattr(self.client, service)
             endpoint_method = getattr(service_client, endpoint)
-            
+
             # Store the endpoint method for later use
             self.endpoint_method = endpoint_method
-            
+
             # Check if the endpoint has a batch variant
             self.has_batch = hasattr(service_client, f"batch_{endpoint}")
             if self.has_batch:
                 self.batch_method = getattr(service_client, f"batch_{endpoint}")
-            
+
             # Check if the endpoint has an async variant
             self.has_async = hasattr(service_client, f"{endpoint}_async")
             if self.has_async:
                 self.async_method = getattr(service_client, f"{endpoint}_async")
-                
-            logger.info(f"Initialized {self.step_id} with endpoint {service}.{endpoint}")
-            logger.debug(f"Batch support: {self.has_batch}, Async support: {self.has_async}")
-            
+
+            logger.info(
+                f"Initialized {self.step_id} with endpoint {service}.{endpoint}"
+            )
+            logger.debug(
+                f"Batch support: {self.has_batch}, Async support: {self.has_async}"
+            )
+
         except AttributeError as e:
-            raise ValueError(f"Invalid service or endpoint: {service}.{endpoint}") from e
-    
-    def process(self, inputs: List[InputType], context: PipelineContext) -> List[OutputType]:
+            raise ValueError(
+                f"Invalid service or endpoint: {service}.{endpoint}"
+            ) from e
+
+    def process(
+        self, inputs: List[InputType], context: PipelineContext
+    ) -> List[OutputType]:
         """
         Process a batch of inputs using a Marovi API endpoint.
-        
+
         Args:
             inputs: List of inputs to process
             context: Pipeline context
-            
+
         Returns:
             List of outputs
         """
-        logger.info(f"{self.step_id}: Processing {len(inputs)} items {self.process_mode}ly")
-        
+        logger.info(
+            f"{self.step_id}: Processing {len(inputs)} items {self.process_mode}ly"
+        )
+
         # Ensure API client is initialized
         if self.client is None:
             self.client = MaroviAPI()
-        
+
         results = []
-        
+
         # Get the service and endpoint functions
         service = getattr(self.client, self.service, None)
         if service is None:
             raise ValueError(f"Service '{self.service}' not found in API client")
-        
+
         endpoint_fn = getattr(service, self.endpoint, None)
         if endpoint_fn is None:
-            raise ValueError(f"Endpoint '{self.endpoint}' not found in service '{self.service}'")
-        
+            raise ValueError(
+                f"Endpoint '{self.endpoint}' not found in service '{self.service}'"
+            )
+
         # Process each input
         for input_item in inputs:
             try:
                 # Prepare the endpoint arguments
                 kwargs = self.endpoint_kwargs.copy() if self.endpoint_kwargs else {}
-                
+
                 # Extract input field from the input item
                 if self.input_field:
                     if isinstance(input_item, dict):
                         input_value = input_item.get(self.input_field)
                     else:
                         input_value = input_item
-                    
+
                     # Add to kwargs
                     kwargs[self.input_field] = input_value
-                    logger.debug(f"{self.step_id}: Input: {input_value[:100]}{'...' if len(str(input_value)) > 100 else ''}")
+                    logger.debug(
+                        f"{self.step_id}: Input: {input_value[:100]}{'...' if len(str(input_value)) > 100 else ''}"
+                    )
                 elif isinstance(input_item, dict):
                     # Use the entire dictionary as kwargs
                     kwargs.update(input_item)
                 else:
                     # Use the item directly
-                    kwargs['text'] = input_item
-                    logger.debug(f"{self.step_id}: Input: {input_item[:100]}{'...' if len(str(input_item)) > 100 else ''}")
-                
+                    kwargs["text"] = input_item
+                    logger.debug(
+                        f"{self.step_id}: Input: {input_item[:100]}{'...' if len(str(input_item)) > 100 else ''}"
+                    )
+
                 # Log the request
-                logger.debug(f"{self.step_id}: Request to {self.service}.{self.endpoint}: {kwargs}")
-                
+                logger.debug(
+                    f"{self.step_id}: Request to {self.service}.{self.endpoint}: {kwargs}"
+                )
+
                 # Call the endpoint
                 response = endpoint_fn(**kwargs)
-                
+
                 # Log the response
                 logger.debug(f"{self.step_id}: Response: {response}")
-                
+
                 # Extract output field from response
                 if self.output_field:
                     if isinstance(response, dict):
                         output_value = response.get(self.output_field)
                         results.append(output_value)
                     else:
-                        logger.error(f"{self.step_id}: Cannot extract '{self.output_field}' from non-dict response: {response}")
-                        raise ValueError(f"Cannot extract '{self.output_field}' from non-dict response")
+                        logger.error(
+                            f"{self.step_id}: Cannot extract '{self.output_field}' from non-dict response: {response}"
+                        )
+                        raise ValueError(
+                            f"Cannot extract '{self.output_field}' from non-dict response"
+                        )
                 else:
                     # Use the entire response
                     results.append(response)
-                    
+
             except Exception as e:
                 logger.error(f"{self.step_id}: Processing item failed: {str(e)}")
                 raise
-        
+
         return results
 
 
 # Convenience factory methods for common API endpoints
 
-def TranslateStep(source_lang: str, target_lang: str, provider: str = "google", 
-                 batch_size: int = 10, step_id: Optional[str] = None) -> MaroviAPIStep[str, str]:
+
+def TranslateStep(
+    source_lang: str,
+    target_lang: str,
+    provider: str = "google",
+    batch_size: int = 10,
+    step_id: Optional[str] = None,
+) -> MaroviAPIStep[str, str]:
     """
     Create a step that translates text using the MaroviAPI translation service.
-    
+
     Args:
         source_lang: Source language code
         target_lang: Target language code
         provider: Translation provider to use
         batch_size: Number of items to process in a batch
         step_id: Optional unique identifier for this step
-        
+
     Returns:
         A configured MaroviAPIStep for translation
     """
@@ -206,26 +250,31 @@ def TranslateStep(source_lang: str, target_lang: str, provider: str = "google",
         endpoint_kwargs={
             "source_lang": source_lang,
             "target_lang": target_lang,
-            "provider": provider
+            "provider": provider,
         },
         input_field="text",
         batch_size=batch_size,
-        step_id=step_id or f"translate_{source_lang}_to_{target_lang}"
+        step_id=step_id or f"translate_{source_lang}_to_{target_lang}",
     )
 
 
-def LLMTranslateStep(source_lang: str, target_lang: str, provider: str = "openai", 
-                    batch_size: int = 5, step_id: Optional[str] = None) -> MaroviAPIStep[str, Dict[str, str]]:
+def LLMTranslateStep(
+    source_lang: str,
+    target_lang: str,
+    provider: str = "openai",
+    batch_size: int = 5,
+    step_id: Optional[str] = None,
+) -> MaroviAPIStep[str, Dict[str, str]]:
     """
     Create a step that translates text using the MaroviAPI custom LLM translation endpoint.
-    
+
     Args:
         source_lang: Source language code
         target_lang: Target language code
         provider: LLM provider to use
         batch_size: Number of items to process in a batch
         step_id: Optional unique identifier for this step
-        
+
     Returns:
         A configured MaroviAPIStep for LLM-based translation
     """
@@ -235,39 +284,40 @@ def LLMTranslateStep(source_lang: str, target_lang: str, provider: str = "openai
         endpoint_kwargs={
             "source_lang": source_lang,
             "target_lang": target_lang,
-            "provider": provider
+            "provider": provider,
         },
         input_field="text",
         output_field="translated_text",
         batch_size=batch_size,
-        step_id=step_id or f"llm_translate_{source_lang}_to_{target_lang}"
+        step_id=step_id or f"llm_translate_{source_lang}_to_{target_lang}",
     )
 
 
-def SummarizeStep(style: str = "paragraph", max_length: Optional[int] = None,
-                 include_keywords: bool = False, batch_size: int = 5,
-                 step_id: Optional[str] = None) -> MaroviAPIStep[str, Dict[str, Any]]:
+def SummarizeStep(
+    style: str = "paragraph",
+    max_length: Optional[int] = None,
+    include_keywords: bool = False,
+    batch_size: int = 5,
+    step_id: Optional[str] = None,
+) -> MaroviAPIStep[str, Dict[str, Any]]:
     """
     Create a step that summarizes text using the MaroviAPI custom summarization endpoint.
-    
+
     Args:
         style: Summary style ("paragraph" or "bullet")
         max_length: Maximum length of the summary in words
         include_keywords: Whether to include keywords in the summary
         batch_size: Number of items to process in a batch
         step_id: Optional unique identifier for this step
-        
+
     Returns:
         A configured MaroviAPIStep for summarization
     """
-    endpoint_kwargs = {
-        "style": style,
-        "include_keywords": include_keywords
-    }
-    
+    endpoint_kwargs = {"style": style, "include_keywords": include_keywords}
+
     if max_length is not None:
         endpoint_kwargs["max_length"] = max_length
-    
+
     return MaroviAPIStep(
         service="custom",
         endpoint="summarize",
@@ -275,43 +325,49 @@ def SummarizeStep(style: str = "paragraph", max_length: Optional[int] = None,
         input_field="text",
         output_field="summary",
         batch_size=batch_size,
-        step_id=step_id or f"summarize_{style}"
+        step_id=step_id or f"summarize_{style}",
     )
 
 
-def CompleteStep(temperature: float = 0.7, max_tokens: int = 150, 
-                batch_size: int = 5, step_id: Optional[str] = None) -> MaroviAPIStep[str, str]:
+def CompleteStep(
+    temperature: float = 0.7,
+    max_tokens: int = 150,
+    batch_size: int = 5,
+    step_id: Optional[str] = None,
+) -> MaroviAPIStep[str, str]:
     """
     Create a step that generates text completions using the MaroviAPI LLM service.
-    
+
     Args:
         temperature: Sampling temperature for the LLM
         max_tokens: Maximum number of tokens to generate
         batch_size: Number of items to process in a batch
         step_id: Optional unique identifier for this step
-        
+
     Returns:
         A configured MaroviAPIStep for LLM completion
     """
     return MaroviAPIStep(
         service="llm",
         endpoint="complete",
-        endpoint_kwargs={
-            "temperature": temperature,
-            "max_tokens": max_tokens
-        },
+        endpoint_kwargs={"temperature": temperature, "max_tokens": max_tokens},
         input_field="prompt",
         batch_size=batch_size,
-        step_id=step_id or "llm_completion"
+        step_id=step_id or "llm_completion",
     )
 
 
-def ConvertFormatStep(source_format: str, target_format: str, 
-                     preserve_structure: bool = True, preserve_links: bool = True,
-                     batch_size: int = 10, step_id: Optional[str] = None) -> MaroviAPIStep[str, Dict[str, str]]:
+def ConvertFormatStep(
+    source_format: str,
+    target_format: str,
+    preserve_structure: bool = True,
+    preserve_links: bool = True,
+    batch_size: int = 10,
+    step_id: Optional[str] = None,
+) -> MaroviAPIStep[str, Dict[str, str]]:
     """
     Create a step that converts text between formats using the MaroviAPI custom format conversion endpoint.
-    
+
     Args:
         source_format: Source format (e.g., "html", "markdown")
         target_format: Target format (e.g., "html", "markdown")
@@ -319,7 +375,7 @@ def ConvertFormatStep(source_format: str, target_format: str,
         preserve_links: Whether to preserve links
         batch_size: Number of items to process in a batch
         step_id: Optional unique identifier for this step
-        
+
     Returns:
         A configured MaroviAPIStep for format conversion
     """
@@ -330,23 +386,29 @@ def ConvertFormatStep(source_format: str, target_format: str,
             "source_format": source_format,
             "target_format": target_format,
             "preserve_structure": preserve_structure,
-            "preserve_links": preserve_links
+            "preserve_links": preserve_links,
         },
         input_field="text",
         output_field="converted_text",
         batch_size=batch_size,
-        step_id=step_id or f"convert_{source_format}_to_{target_format}"
+        step_id=step_id or f"convert_{source_format}_to_{target_format}",
     )
 
 
-def CleanTextStep(format_value: str, remove_html_artifacts: bool = True,
-                 preserve_structure: bool = True, preserve_links: bool = True,
-                 preserve_images: bool = True, provider: str = "openai", 
-                 temperature: float = 0.1, batch_size: int = 5,
-                 step_id: Optional[str] = None) -> MaroviAPIStep[str, Dict[str, str]]:
+def CleanTextStep(
+    format_value: str,
+    remove_html_artifacts: bool = True,
+    preserve_structure: bool = True,
+    preserve_links: bool = True,
+    preserve_images: bool = True,
+    provider: str = "openai",
+    temperature: float = 0.1,
+    batch_size: int = 5,
+    step_id: Optional[str] = None,
+) -> MaroviAPIStep[str, Dict[str, str]]:
     """
     Create a step that cleans text from artifacts and leftover markup using the MaroviAPI custom text cleaner.
-    
+
     Args:
         format_value: Format of the text to clean (e.g., "wiki", "markdown", "html")
         remove_html_artifacts: Whether to remove HTML artifacts from the text
@@ -357,7 +419,7 @@ def CleanTextStep(format_value: str, remove_html_artifacts: bool = True,
         temperature: Sampling temperature for the LLM
         batch_size: Number of items to process in a batch
         step_id: Optional unique identifier for this step
-        
+
     Returns:
         A configured MaroviAPIStep for text cleaning
     """
@@ -371,13 +433,10 @@ def CleanTextStep(format_value: str, remove_html_artifacts: bool = True,
             "preserve_links": preserve_links,
             "preserve_images": preserve_images,
             "provider": provider,
-            "options": {
-                "temperature": temperature,
-                "structured_response": True
-            }
+            "options": {"temperature": temperature, "structured_response": True},
         },
         input_field="text",
         output_field="cleaned_text",
         batch_size=batch_size,
-        step_id=step_id or f"clean_{format_value}_text"
+        step_id=step_id or f"clean_{format_value}_text",
     )

--- a/marovi/modules/steps/parsing.py
+++ b/marovi/modules/steps/parsing.py
@@ -19,34 +19,38 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # Type variables for parser steps
-InputPathType = TypeVar('InputPathType')
-ParsedType = TypeVar('ParsedType')
-OutputType = TypeVar('OutputType')
+InputPathType = TypeVar("InputPathType")
+ParsedType = TypeVar("ParsedType")
+OutputType = TypeVar("OutputType")
 
 __all__ = [
-    'ParserStep',
-    'WriterStep',
-    'TranslationConnectorStep',
-    'POFileParserStep',
-    'POFileWriterStep'
+    "ParserStep",
+    "WriterStep",
+    "TranslationConnectorStep",
+    "POFileParserStep",
+    "POFileWriterStep",
 ]
 
 
-class ParserStep(PipelineStep[InputPathType, ParsedType], Generic[InputPathType, ParsedType], ABC):
+class ParserStep(
+    PipelineStep[InputPathType, ParsedType], Generic[InputPathType, ParsedType], ABC
+):
     """
     A generic pipeline step for parsing files and extracting their content.
-    
+
     This base class defines the interface for parser steps and provides
     common functionality like storing metadata in the pipeline context.
     """
-    
-    def __init__(self, 
-                 batch_size: int = 5,
-                 process_mode: str = 'sequential',
-                 step_id: str = "parser"):
+
+    def __init__(
+        self,
+        batch_size: int = 5,
+        process_mode: str = "sequential",
+        step_id: str = "parser",
+    ):
         """
         Initialize the generic parser step.
-        
+
         Args:
             batch_size: Number of files to process in a batch
             process_mode: Processing mode ('sequential' or 'parallel')
@@ -54,81 +58,93 @@ class ParserStep(PipelineStep[InputPathType, ParsedType], Generic[InputPathType,
         """
         super().__init__(
             batch_size=batch_size,
-            batch_handling='wrap',
+            batch_handling="wrap",
             process_mode=process_mode,
-            step_id=step_id
+            step_id=step_id,
         )
-    
+
     @abstractmethod
     def parse_file(self, file_path: str) -> Tuple[ParsedType, Dict[str, Any]]:
         """
         Parse a single file and extract its content.
-        
+
         Args:
             file_path: Path to the file to parse
-            
+
         Returns:
             Tuple containing (parsed_content, metadata)
         """
         pass
-    
-    def process(self, inputs: List[InputPathType], context: PipelineContext) -> List[ParsedType]:
+
+    def process(
+        self, inputs: List[InputPathType], context: PipelineContext
+    ) -> List[ParsedType]:
         """
         Process a list of file paths and extract content.
-        
+
         Args:
             inputs: List of file paths or input sources
             context: Pipeline context
-            
+
         Returns:
             List of parsed content
         """
         if not inputs:
             logger.warning(f"{self.step_id}: No inputs provided")
             return []
-        
+
         results = []
         metadata_list = []
-        
+
         for input_source in inputs:
             try:
                 # Get file path if input is not a string
-                file_path = str(input_source) if isinstance(input_source, (str, os.PathLike)) else input_source
-                
+                file_path = (
+                    str(input_source)
+                    if isinstance(input_source, (str, os.PathLike))
+                    else input_source
+                )
+
                 logger.info(f"{self.step_id}: Processing input {file_path}")
-                
+
                 # Parse the file
                 parsed_content, metadata = self.parse_file(file_path)
-                
+
                 # Store results and metadata
                 results.append(parsed_content)
                 metadata_list.append(metadata)
-                
+
             except Exception as e:
-                logger.error(f"{self.step_id}: Error processing {input_source}: {str(e)}")
-        
+                logger.error(
+                    f"{self.step_id}: Error processing {input_source}: {str(e)}"
+                )
+
         # Store metadata in context
         context.add_metadata(f"{self.step_id}_metadata", metadata_list)
-        
+
         return results
 
 
-class WriterStep(PipelineStep[InputPathType, OutputType], Generic[InputPathType, OutputType], ABC):
+class WriterStep(
+    PipelineStep[InputPathType, OutputType], Generic[InputPathType, OutputType], ABC
+):
     """
     A generic pipeline step for writing processed content back to files.
-    
+
     This base class defines the interface for writer steps and provides
     common functionality for determining output paths and writing files.
     """
-    
-    def __init__(self, 
-                 output_dir: Optional[str] = None,
-                 batch_size: int = 5,
-                 process_mode: str = 'sequential',
-                 step_id: str = "writer"):
+
+    def __init__(
+        self,
+        output_dir: Optional[str] = None,
+        batch_size: int = 5,
+        process_mode: str = "sequential",
+        step_id: str = "writer",
+    ):
         """
         Initialize the generic writer step.
-        
+
         Args:
             output_dir: Directory to save output files (if None, uses same directory as input)
             batch_size: Number of files to process in a batch
@@ -137,118 +153,126 @@ class WriterStep(PipelineStep[InputPathType, OutputType], Generic[InputPathType,
         """
         super().__init__(
             batch_size=batch_size,
-            batch_handling='wrap',
+            batch_handling="wrap",
             process_mode=process_mode,
-            step_id=step_id
+            step_id=step_id,
         )
         self.output_dir = output_dir
-    
+
     @abstractmethod
     def write_file(self, content: Any, metadata: Dict[str, Any]) -> str:
         """
         Write content to a file.
-        
+
         Args:
             content: Content to write
             metadata: Metadata about the file
-            
+
         Returns:
             Path to the written file
         """
         pass
-    
+
     def get_output_path(self, input_path: str) -> str:
         """
         Determine the output path for a processed file.
-        
+
         Args:
             input_path: Path to the input file
-            
+
         Returns:
             Path to the output file
         """
         if not self.output_dir:
             return input_path
-        
+
         filename = os.path.basename(input_path)
         return os.path.join(self.output_dir, filename)
-    
-    def process(self, inputs: List[InputPathType], context: PipelineContext) -> List[OutputType]:
+
+    def process(
+        self, inputs: List[InputPathType], context: PipelineContext
+    ) -> List[OutputType]:
         """
         Process a list of items and write them to files.
-        
+
         Args:
             inputs: List of items to write
             context: Pipeline context with metadata
-            
+
         Returns:
             List of outputs (usually file paths)
         """
         if not inputs:
             logger.warning(f"{self.step_id}: No inputs provided")
             return []
-        
+
         # Get most recent parser metadata from context
         metadata_key = None
         for key in context.metadata:
             if key.endswith("_metadata") and key != f"{self.step_id}_metadata":
                 metadata_key = key
                 break
-        
+
         if not metadata_key:
             logger.error(f"{self.step_id}: No metadata found in context")
             return []
-        
+
         metadata_list = context.metadata.get(metadata_key, [])
         if len(inputs) != len(metadata_list):
-            logger.error(f"{self.step_id}: Number of inputs ({len(inputs)}) does not match metadata count ({len(metadata_list)})")
+            logger.error(
+                f"{self.step_id}: Number of inputs ({len(inputs)}) does not match metadata count ({len(metadata_list)})"
+            )
             return []
-        
+
         results = []
-        
+
         for item, metadata in zip(inputs, metadata_list):
             try:
                 # Write the file
                 output_path = self.write_file(item, metadata)
                 results.append(output_path)
-                
+
             except Exception as e:
                 logger.error(f"{self.step_id}: Error writing file: {str(e)}")
-        
+
         return results
 
 
 class TranslationConnectorStep(PipelineStep[List[str], Dict[str, Any]]):
     """
     A connector step that combines translated texts with original file metadata.
-    
+
     This step is necessary to connect the translation step with the writer step,
     ensuring that translations are properly associated with their source files.
     """
-    
-    def __init__(self, parser_metadata_key: Optional[str] = None, step_id: str = "translation_connector"):
+
+    def __init__(
+        self,
+        parser_metadata_key: Optional[str] = None,
+        step_id: str = "translation_connector",
+    ):
         """
         Initialize the connector step.
-        
+
         Args:
             parser_metadata_key: Key to use for retrieving parser metadata (if None, auto-detect)
             step_id: Unique identifier for this step
         """
         super().__init__(
-            batch_handling='wrap',
-            process_mode='sequential',
-            step_id=step_id
+            batch_handling="wrap", process_mode="sequential", step_id=step_id
         )
         self.parser_metadata_key = parser_metadata_key
-    
-    def process(self, inputs: List[List[str]], context: PipelineContext) -> List[Dict[str, Any]]:
+
+    def process(
+        self, inputs: List[List[str]], context: PipelineContext
+    ) -> List[Dict[str, Any]]:
         """
         Combine translated texts with file metadata.
-        
+
         Args:
             inputs: List of lists of translated texts
             context: Pipeline context with file metadata
-            
+
         Returns:
             List of dictionaries with file metadata and translations
         """
@@ -259,43 +283,47 @@ class TranslationConnectorStep(PipelineStep[List[str], Dict[str, Any]]):
                 if key.endswith("_metadata"):
                     metadata_key = key
                     break
-        
+
         # Retrieve file metadata from context
         file_metadata = context.metadata.get(metadata_key, []) if metadata_key else None
         if not file_metadata:
             logger.error(f"{self.step_id}: No file metadata found in context")
             return []
-        
+
         if len(inputs) != len(file_metadata):
-            logger.error(f"{self.step_id}: Number of translation sets ({len(inputs)}) does not match metadata count ({len(file_metadata)})")
+            logger.error(
+                f"{self.step_id}: Number of translation sets ({len(inputs)}) does not match metadata count ({len(file_metadata)})"
+            )
             return []
-        
+
         # Combine translations with metadata
         results = []
         for translations, metadata in zip(inputs, file_metadata):
             result = metadata.copy()
             result["translations"] = translations
             results.append(result)
-        
+
         return results
 
 
 class POFileParserStep(ParserStep[str, List[str]]):
     """
     A pipeline step for parsing PO files and extracting their content for translation.
-    
+
     This step takes file paths as input and returns lists of messages to translate.
     It also stores file metadata in the pipeline context for later retrieval.
     """
-    
-    def __init__(self, 
-                 source_lang: str = "en",
-                 include_translated: bool = False,
-                 batch_size: int = 5,
-                 step_id: str = "po_file_parser"):
+
+    def __init__(
+        self,
+        source_lang: str = "en",
+        include_translated: bool = False,
+        batch_size: int = 5,
+        step_id: str = "po_file_parser",
+    ):
         """
         Initialize the PO file parser step.
-        
+
         Args:
             source_lang: Source language code (e.g., 'en')
             include_translated: Whether to include already translated entries
@@ -303,91 +331,91 @@ class POFileParserStep(ParserStep[str, List[str]]):
             step_id: Unique identifier for this step
         """
         super().__init__(
-            batch_size=batch_size,
-            process_mode='sequential',
-            step_id=step_id
+            batch_size=batch_size, process_mode="sequential", step_id=step_id
         )
         self.source_lang = source_lang
         self.include_translated = include_translated
-    
+
     def parse_file(self, file_path: str) -> Tuple[List[str], Dict[str, Any]]:
         """
         Parse a PO file and extract its content.
-        
+
         Args:
             file_path: Path to the PO file
-            
+
         Returns:
             Tuple containing (texts_to_translate, metadata)
         """
         # Validate file exists
         if not os.path.exists(file_path):
             raise FileNotFoundError(f"File does not exist: {file_path}")
-        
+
         # Parse the PO file
         parser = POParser()
         parser.load_from_file(file_path, include_translated=self.include_translated)
-        
+
         # Extract messages
         messages = parser.get_messages()
-        
+
         # Extract target language from filename or path
         target_lang = self._extract_target_lang(file_path)
-        
+
         # Create default metadata even if there are no messages
         metadata = {
             "file_path": file_path,
             "source_lang": self.source_lang,
             "target_lang": target_lang,
             "message_count": len(messages),
-            "parser": parser  # Store the parser instance for later use
+            "parser": parser,  # Store the parser instance for later use
         }
-        
+
         # If no messages found, return empty list but still include metadata
         if not messages:
             logger.warning(f"No messages found in {file_path}")
             return [], metadata
-        
+
         # Extract texts to translate
         texts_to_translate = [msg[0] for msg in messages]
-        
+
         return texts_to_translate, metadata
-    
+
     def _extract_target_lang(self, file_path: str) -> str:
         """
         Extract target language from file path.
-        
+
         Args:
             file_path: Path to the PO file
-            
+
         Returns:
             Language code extracted from the filename or 'unknown'
         """
         # Try to extract language code from filename (e.g., page-Welcome_es.po)
         filename = os.path.basename(file_path)
-        if '_' in filename:
-            lang_code = filename.split('_')[-1].split('.')[0]
+        if "_" in filename:
+            lang_code = filename.split("_")[-1].split(".")[0]
             if len(lang_code) == 2:  # Basic validation
                 return lang_code
-        
+
         return "unknown"
 
 
 class POFileWriterStep(WriterStep[Dict[str, Any], str]):
     """
     A pipeline step for writing translated content back to PO files.
-    
+
     This step takes dictionaries with parsed content and translations,
     then saves the translations back to PO files.
     """
-    
-    def __init__(self, 
-                 output_dir: Optional[str] = None,
-                 batch_size: int = 5,
-                 step_id: str = "po_file_writer"):
+
+    def __init__(
+        self,
+        output_dir: Optional[str] = None,
+        batch_size: int = 5,
+        step_id: str = "po_file_writer",
+    ):
         """
         Initialize the PO file writer step.
-        
+
         Args:
             output_dir: Directory to save output files (if None, uses same directory as input)
             batch_size: Number of files to process in a batch
@@ -396,38 +424,38 @@ class POFileWriterStep(WriterStep[Dict[str, Any], str]):
         super().__init__(
             output_dir=output_dir,
             batch_size=batch_size,
-            process_mode='sequential',
-            step_id=step_id
+            process_mode="sequential",
+            step_id=step_id,
         )
-    
+
     def write_file(self, content: Dict[str, Any], metadata: Dict[str, Any]) -> str:
         """
         Write translations to a PO file.
-        
+
         Args:
             content: Dictionary with translations
             metadata: Metadata about the file
-            
+
         Returns:
             Path to the saved PO file
         """
         file_path = metadata.get("file_path")
         parser = metadata.get("parser")
-        
+
         if not file_path or not parser:
             raise ValueError("Missing required data for saving")
 
         # Get translations or use empty list if not available
         translations = content.get("translations", [])
-        
+
         # Determine output path
         output_path = self.get_output_path(file_path)
-        
+
         # Create output directory if it doesn't exist
         os.makedirs(os.path.dirname(output_path), exist_ok=True)
-        
+
         # Save translations to PO file
         parser.save_translated_po(output_path, translations)
         logger.info(f"{self.step_id}: Saved translations to {output_path}")
-        
+
         return output_path

--- a/marovi/modules/steps/translation.py
+++ b/marovi/modules/steps/translation.py
@@ -1,8 +1,8 @@
 """
 PO File Translation Steps
 
-This module provides specialized pipeline steps for translating PO (gettext) files 
-using various translation services. These steps handle the extraction of translatable 
+This module provides specialized pipeline steps for translating PO (gettext) files
+using various translation services. These steps handle the extraction of translatable
 text from PO files, translation to multiple languages, and saving the results.
 """
 
@@ -26,21 +26,23 @@ logger = logging.getLogger(__name__)
 class POFileTranslatorStep(PipelineStep[str, Dict[str, List[str]]]):
     """
     A pipeline step for translating PO file content to multiple target languages.
-    
+
     This step takes a path to a PO file, extracts translatable content, and translates
     it to multiple target languages using the specified translation service.
     """
-    
-    def __init__(self, 
-                 source_lang: str = "en",
-                 target_langs: List[str] = None,
-                 translator_type: str = "google",
-                 batch_size: int = 5,
-                 include_translated: bool = False,
-                 step_id: str = "po_file_translator"):
+
+    def __init__(
+        self,
+        source_lang: str = "en",
+        target_langs: List[str] = None,
+        translator_type: str = "google",
+        batch_size: int = 5,
+        include_translated: bool = False,
+        step_id: str = "po_file_translator",
+    ):
         """
         Initialize the PO file translator step.
-        
+
         Args:
             source_lang: Source language code
             target_langs: List of target language codes
@@ -51,16 +53,20 @@ class POFileTranslatorStep(PipelineStep[str, Dict[str, List[str]]]):
         """
         super().__init__(
             batch_size=batch_size,
-            batch_handling='wrap',
-            process_mode='sequential',
-            step_id=step_id
+            batch_handling="wrap",
+            process_mode="sequential",
+            step_id=step_id,
         )
         self.source_lang = source_lang
-        self.target_langs = target_langs or ["es", "fr", "de"]  # Default to common languages
+        self.target_langs = target_langs or [
+            "es",
+            "fr",
+            "de",
+        ]  # Default to common languages
         self.translator_type = translator_type
         self.include_translated = include_translated
         self.api_client = MaroviAPI()
-        
+
         # Create translator functions for each target language
         self.translators = {}
         for lang in self.target_langs:
@@ -68,68 +74,78 @@ class POFileTranslatorStep(PipelineStep[str, Dict[str, List[str]]]):
                 self.translators[lang] = self._create_llm_translator(lang)
             else:
                 self.translators[lang] = self._create_google_translator(lang)
-    
+
     def _create_google_translator(self, target_lang: str):
         """Create a Google Translate function for the target language."""
+
         def translate_text(text: str) -> str:
             return self.api_client.translation.translate(
                 text=text,
                 source_lang=self.source_lang,
                 target_lang=target_lang,
-                provider="google"
+                provider="google",
             )
+
         return translate_text
-    
+
     def _create_llm_translator(self, target_lang: str):
         """Create an LLM-based translate function for the target language."""
+
         def translate_text(text: str) -> str:
             response = self.api_client.custom.llm_translate(
                 text=text,
                 source_lang=self.source_lang,
                 target_lang=target_lang,
-                provider="openai"
+                provider="openai",
             )
             return response.get("translated_text", text)
+
         return translate_text
-    
-    def process(self, inputs: List[str], context: PipelineContext) -> List[Dict[str, List[str]]]:
+
+    def process(
+        self, inputs: List[str], context: PipelineContext
+    ) -> List[Dict[str, List[str]]]:
         """
         Process a list of PO file paths and translate their content.
-        
+
         Args:
             inputs: List of PO file paths
             context: Pipeline context
-            
+
         Returns:
             List of dictionaries mapping target languages to translations
         """
         if not inputs:
             logger.warning(f"{self.step_id}: No inputs provided")
             return []
-        
+
         results = []
         file_metadata = []
-        
+
         for file_path in inputs:
             try:
                 # Parse the PO file
                 parser = POParser()
-                parser.load_from_file(file_path, include_translated=self.include_translated)
-                
+                parser.load_from_file(
+                    file_path, include_translated=self.include_translated
+                )
+
                 # Extract messages to translate
                 messages = parser.get_messages()
                 if not messages:
                     logger.warning(f"No messages found in {file_path}")
                     continue
-                
+
                 texts_to_translate = [msg[0] for msg in messages]
-                
+
                 # Translate to each target language
                 translations = {}
                 for lang in self.target_langs:
-                    logger.info(f"Translating {len(texts_to_translate)} messages to {lang}")
+                    logger.info(
+                        f"Translating {len(texts_to_translate)} messages to {lang}"
+                    )
                     translator = self.translators[lang]
-                    
+
                     # Translate each message
                     translated_texts = []
                     for text in texts_to_translate:
@@ -139,48 +155,50 @@ class POFileTranslatorStep(PipelineStep[str, Dict[str, List[str]]]):
                         except Exception as e:
                             logger.error(f"Error translating to {lang}: {str(e)}")
                             translated_texts.append(text)  # Fall back to original text
-                    
+
                     translations[lang] = translated_texts
-                
+
                 # Create metadata for this file
                 metadata = {
                     "file_path": file_path,
                     "source_lang": self.source_lang,
                     "target_langs": self.target_langs,
                     "message_count": len(messages),
-                    "parser": parser  # Store the parser instance for later use
+                    "parser": parser,  # Store the parser instance for later use
                 }
                 file_metadata.append(metadata)
-                
+
                 results.append(translations)
-                
+
             except Exception as e:
                 logger.error(f"{self.step_id}: Error processing {file_path}: {str(e)}")
-        
+
         # Store metadata in context
         context.add_metadata(f"{self.step_id}_metadata", file_metadata)
-        
+
         return results
 
 
 class POFileBatchTranslatorStep(PipelineStep[List[str], List[Dict[str, List[str]]]]):
     """
     A pipeline step for batch translating multiple PO files to multiple languages.
-    
+
     This step efficiently processes multiple PO files by batching translation requests
     for better performance with translation APIs.
     """
-    
-    def __init__(self,
-                 source_lang: str = "en",
-                 target_langs: List[str] = None,
-                 translator_type: str = "google",
-                 batch_size: int = 10,
-                 include_translated: bool = False,
-                 step_id: str = "po_file_batch_translator"):
+
+    def __init__(
+        self,
+        source_lang: str = "en",
+        target_langs: List[str] = None,
+        translator_type: str = "google",
+        batch_size: int = 10,
+        include_translated: bool = False,
+        step_id: str = "po_file_batch_translator",
+    ):
         """
         Initialize the PO file batch translator step.
-        
+
         Args:
             source_lang: Source language code
             target_langs: List of target language codes
@@ -191,30 +209,30 @@ class POFileBatchTranslatorStep(PipelineStep[List[str], List[Dict[str, List[str]
         """
         super().__init__(
             batch_size=batch_size,
-            batch_handling='inherent',
-            process_mode='sequential',
-            step_id=step_id
+            batch_handling="inherent",
+            process_mode="sequential",
+            step_id=step_id,
         )
         self.source_lang = source_lang
         self.target_langs = target_langs or ["es", "fr", "de"]
         self.translator_type = translator_type
         self.include_translated = include_translated
         self.api_client = MaroviAPI()
-    
+
     def _batch_translate(self, texts: List[str], target_lang: str) -> List[str]:
         """
         Translate a batch of texts to the target language.
-        
+
         Args:
             texts: List of texts to translate
             target_lang: Target language code
-            
+
         Returns:
             List of translated texts
         """
         if not texts:
             return []
-        
+
         try:
             if self.translator_type.lower() == "llm":
                 # Use LLM translation (less efficient for batches but higher quality)
@@ -224,7 +242,7 @@ class POFileBatchTranslatorStep(PipelineStep[List[str], List[Dict[str, List[str]
                         text=text,
                         source_lang=self.source_lang,
                         target_lang=target_lang,
-                        provider="openai"
+                        provider="openai",
                     )
                     translations.append(response.get("translated_text", text))
                 return translations
@@ -234,7 +252,7 @@ class POFileBatchTranslatorStep(PipelineStep[List[str], List[Dict[str, List[str]
                     texts=texts,
                     source_lang=self.source_lang,
                     target_lang=target_lang,
-                    provider="google"
+                    provider="google",
                 )
         except Exception as e:
             logger.error(f"Batch translation error: {str(e)}")
@@ -247,7 +265,7 @@ class POFileBatchTranslatorStep(PipelineStep[List[str], List[Dict[str, List[str]
                             text=text,
                             source_lang=self.source_lang,
                             target_lang=target_lang,
-                            provider="openai"
+                            provider="openai",
                         )
                         translations.append(response.get("translated_text", text))
                     else:
@@ -255,97 +273,105 @@ class POFileBatchTranslatorStep(PipelineStep[List[str], List[Dict[str, List[str]
                             text=text,
                             source_lang=self.source_lang,
                             target_lang=target_lang,
-                            provider="google"
+                            provider="google",
                         )
                         translations.append(translation)
                 except Exception as inner_e:
                     logger.error(f"Individual translation error: {str(inner_e)}")
                     translations.append(text)  # Fall back to original text
             return translations
-    
-    def process(self, inputs: List[List[str]], context: PipelineContext) -> List[List[Dict[str, List[str]]]]:
+
+    def process(
+        self, inputs: List[List[str]], context: PipelineContext
+    ) -> List[List[Dict[str, List[str]]]]:
         """
         Process batches of PO file paths and translate their content.
-        
+
         Args:
             inputs: Batches of PO file paths
             context: Pipeline context
-            
+
         Returns:
             Batches of dictionaries mapping target languages to translations
         """
         if not inputs:
             logger.warning(f"{self.step_id}: No inputs provided")
             return []
-        
+
         # Flatten the input batches for easier processing
         flat_inputs = [item for batch in inputs for item in batch]
-        
+
         all_texts = []
         all_parsers = {}
         file_metadata = []
-        
+
         # First, parse all PO files and extract texts to translate
         for file_path in flat_inputs:
             try:
                 # Parse the PO file
                 parser = POParser()
-                parser.load_from_file(file_path, include_translated=self.include_translated)
-                
+                parser.load_from_file(
+                    file_path, include_translated=self.include_translated
+                )
+
                 # Extract messages to translate
                 messages = parser.get_messages()
                 if not messages:
                     logger.warning(f"No messages found in {file_path}")
                     continue
-                
+
                 texts_to_translate = [msg[0] for msg in messages]
-                
+
                 # Store for later
                 all_texts.append(texts_to_translate)
                 all_parsers[file_path] = parser
-                
+
                 # Create metadata for this file
                 metadata = {
                     "file_path": file_path,
                     "source_lang": self.source_lang,
                     "target_langs": self.target_langs,
                     "message_count": len(messages),
-                    "parser": parser  # Store the parser instance for later use
+                    "parser": parser,  # Store the parser instance for later use
                 }
                 file_metadata.append(metadata)
-                
+
             except Exception as e:
                 logger.error(f"{self.step_id}: Error processing {file_path}: {str(e)}")
-        
+
         # Store metadata in context
         context.add_metadata(f"{self.step_id}_metadata", file_metadata)
-        
+
         if not all_texts:
             logger.warning(f"{self.step_id}: No texts found to translate")
             return []
-        
+
         # Translate for each target language
         results = []
         for i, file_texts in enumerate(all_texts):
             file_path = flat_inputs[i] if i < len(flat_inputs) else "unknown"
-            
+
             translations = {}
             for lang in self.target_langs:
-                logger.info(f"Translating {len(file_texts)} messages from {file_path} to {lang}")
-                
+                logger.info(
+                    f"Translating {len(file_texts)} messages from {file_path} to {lang}"
+                )
+
                 # Batch translate all texts for this file
                 translated_texts = self._batch_translate(file_texts, lang)
-                
+
                 # Ensure we have translations for all texts
                 if len(translated_texts) < len(file_texts):
-                    logger.warning(f"Missing translations: expected {len(file_texts)}, got {len(translated_texts)}")
+                    logger.warning(
+                        f"Missing translations: expected {len(file_texts)}, got {len(translated_texts)}"
+                    )
                     # Fill in missing translations with original text
-                    translated_texts.extend(file_texts[len(translated_texts):])
-                
+                    translated_texts.extend(file_texts[len(translated_texts) :])
+
                 translations[lang] = translated_texts
-            
+
             results.append(translations)
-        
+
         # Re-batch the results to match the input structure
         batched_results = []
         start_idx = 0
@@ -354,25 +380,29 @@ class POFileBatchTranslatorStep(PipelineStep[List[str], List[Dict[str, List[str]
             end_idx = start_idx + batch_size
             batched_results.append(results[start_idx:end_idx])
             start_idx = end_idx
-        
+
         return batched_results
 
 
-class POFileWriterWithMultiLanguageSupport(PipelineStep[Dict[str, List[str]], Dict[str, List[str]]]):
+class POFileWriterWithMultiLanguageSupport(
+    PipelineStep[Dict[str, List[str]], Dict[str, List[str]]]
+):
     """
     A pipeline step for writing translated PO files for multiple target languages.
-    
+
     This step takes dictionaries of translations (one per target language) and writes
     them to PO files, creating separate files for each target language.
     """
-    
-    def __init__(self,
-                 output_dir: Optional[str] = None,
-                 batch_size: int = 5,
-                 step_id: str = "po_file_multi_writer"):
+
+    def __init__(
+        self,
+        output_dir: Optional[str] = None,
+        batch_size: int = 5,
+        step_id: str = "po_file_multi_writer",
+    ):
         """
         Initialize the multi-language PO file writer step.
-        
+
         Args:
             output_dir: Directory to save output files (if None, uses same directory as input)
             batch_size: Number of files to process in a batch
@@ -380,32 +410,32 @@ class POFileWriterWithMultiLanguageSupport(PipelineStep[Dict[str, List[str]], Di
         """
         super().__init__(
             batch_size=batch_size,
-            batch_handling='wrap',
-            process_mode='sequential',
-            step_id=step_id
+            batch_handling="wrap",
+            process_mode="sequential",
+            step_id=step_id,
         )
         self.output_dir = output_dir
-    
+
     def _get_output_path(self, input_path: str, target_lang: str) -> str:
         """
         Determine the output path for a translated PO file.
-        
+
         Args:
             input_path: Path to the input file
             target_lang: Target language code
-            
+
         Returns:
             Path to the output file
         """
         # If no output directory specified, use same directory as input
         output_dir = self.output_dir or os.path.dirname(input_path)
-        
+
         # Create the output directory if it doesn't exist
         os.makedirs(output_dir, exist_ok=True)
-        
+
         # Extract the input filename
         basename = os.path.basename(input_path)
-        
+
         # Insert the target language into the filename
         # Assume filename format: something_XX.po or page-Something_XX.po
         if "_" in basename:
@@ -420,66 +450,76 @@ class POFileWriterWithMultiLanguageSupport(PipelineStep[Dict[str, List[str]], Di
         else:
             # No language code in the filename, just add it
             new_basename = basename.replace(".po", f"_{target_lang}.po")
-        
+
         return os.path.join(output_dir, new_basename)
-    
-    def process(self, inputs: List[Dict[str, List[str]]], context: PipelineContext) -> List[Dict[str, List[str]]]:
+
+    def process(
+        self, inputs: List[Dict[str, List[str]]], context: PipelineContext
+    ) -> List[Dict[str, List[str]]]:
         """
         Process a list of translation dictionaries and write them to PO files.
-        
+
         Args:
             inputs: List of dictionaries mapping target languages to translations
             context: Pipeline context
-            
+
         Returns:
             List of dictionaries mapping target languages to output file paths
         """
         if not inputs:
             logger.warning(f"{self.step_id}: No inputs provided")
             return []
-        
+
         # Get metadata from context
         metadata_key = None
         for key in context.metadata:
             if key.endswith("_metadata") and key != f"{self.step_id}_metadata":
                 metadata_key = key
                 break
-        
+
         if not metadata_key:
             logger.error(f"{self.step_id}: No metadata found in context")
             return []
-        
+
         file_metadata = context.get_metadata(metadata_key)
         if len(inputs) != len(file_metadata):
-            logger.error(f"{self.step_id}: Metadata count ({len(file_metadata)}) does not match input count ({len(inputs)})")
+            logger.error(
+                f"{self.step_id}: Metadata count ({len(file_metadata)}) does not match input count ({len(inputs)})"
+            )
             return []
-        
+
         results = []
-        
+
         for translations_dict, metadata in zip(inputs, file_metadata):
             input_path = metadata.get("file_path", "unknown")
             parser = metadata.get("parser")
-            
+
             if not parser:
-                logger.error(f"{self.step_id}: No parser found in metadata for {input_path}")
+                logger.error(
+                    f"{self.step_id}: No parser found in metadata for {input_path}"
+                )
                 continue
-            
+
             output_paths = {}
-            
+
             for lang, translations in translations_dict.items():
                 output_path = self._get_output_path(input_path, lang)
-                
+
                 try:
                     # Save translations to PO file
                     parser.save_translated_po(output_path, translations)
-                    logger.info(f"{self.step_id}: Saved {lang} translations to {output_path}")
-                    
+                    logger.info(
+                        f"{self.step_id}: Saved {lang} translations to {output_path}"
+                    )
+
                     output_paths[lang] = output_path
-                    
+
                 except Exception as e:
-                    logger.error(f"{self.step_id}: Error saving {lang} translations to {output_path}: {str(e)}")
+                    logger.error(
+                        f"{self.step_id}: Error saving {lang} translations to {output_path}: {str(e)}"
+                    )
                     output_paths[lang] = None
-            
+
             results.append(output_paths)
-        
+
         return results

--- a/marovi/pipelines/__init__.py
+++ b/marovi/pipelines/__init__.py
@@ -7,8 +7,4 @@ This package provides pipeline components for document processing tasks.
 from marovi.pipelines.core import Pipeline, PipelineStep
 from marovi.pipelines.context import PipelineContext
 
-__all__ = [
-    'Pipeline',
-    'PipelineStep',
-    'PipelineContext'
-]
+__all__ = ["Pipeline", "PipelineStep", "PipelineContext"]

--- a/marovi/pipelines/po_translation.py
+++ b/marovi/pipelines/po_translation.py
@@ -13,14 +13,17 @@ from typing import List, Optional, Dict, Any, Union
 from marovi.pipelines.core import Pipeline
 from marovi.pipelines.context import PipelineContext
 from marovi.pipelines.utils.base import BasePipeline
-from marovi.modules.steps.parsing import POFileParserStep, POFileWriterStep, TranslationConnectorStep
+from marovi.modules.steps.parsing import (
+    POFileParserStep,
+    POFileWriterStep,
+    TranslationConnectorStep,
+)
 from marovi.modules.steps.marovi_api import TranslateStep, LLMTranslateStep
 from marovi.api.core.client import MaroviAPI
 
 # Configure logging
 logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger(__name__)
 
@@ -28,19 +31,23 @@ logger = logging.getLogger(__name__)
 class POTranslationPipeline(BasePipeline):
     """
     Pipeline for translating PO files from one language to another.
-    
+
     This pipeline handles the entire process of:
     1. Parsing PO files
     2. Translating their content
     3. Saving the translations back to PO files
-    
+
     It supports both Google Translate and LLM-based translation.
     """
-    
-    def __init__(self, name: str = "po_translation_pipeline", description: str = "Translate PO files"):
+
+    def __init__(
+        self,
+        name: str = "po_translation_pipeline",
+        description: str = "Translate PO files",
+    ):
         """
         Initialize the PO translation pipeline.
-        
+
         Args:
             name: Name of the pipeline
             description: Description of the pipeline's purpose
@@ -48,17 +55,19 @@ class POTranslationPipeline(BasePipeline):
         super().__init__(name=name, description=description)
         self.pipeline = None
         self.context = None
-    
-    def build_pipeline(self, 
-                      source_lang: str = "en",
-                      target_lang: str = "es",
-                      output_dir: Optional[str] = None,
-                      translator_type: str = "google",
-                      batch_size: int = 5,
-                      **kwargs) -> Pipeline:
+
+    def build_pipeline(
+        self,
+        source_lang: str = "en",
+        target_lang: str = "es",
+        output_dir: Optional[str] = None,
+        translator_type: str = "google",
+        batch_size: int = 5,
+        **kwargs,
+    ) -> Pipeline:
         """
         Build the pipeline with the given configuration.
-        
+
         Args:
             source_lang: Source language code
             target_lang: Target language code
@@ -66,56 +75,54 @@ class POTranslationPipeline(BasePipeline):
             translator_type: Type of translator to use ('google' or 'llm')
             batch_size: Batch size for processing
             **kwargs: Additional configuration parameters
-            
+
         Returns:
             The constructed pipeline
         """
         # Create parser step
         parser_step = POFileParserStep(source_lang=source_lang, batch_size=batch_size)
-        
+
         # Create appropriate translator step based on type
         if translator_type.lower() == "llm":
             translator_step = LLMTranslateStep(
-                source_lang=source_lang,
-                target_lang=target_lang,
-                batch_size=batch_size
+                source_lang=source_lang, target_lang=target_lang, batch_size=batch_size
             )
         else:  # Default to Google
             translator_step = TranslateStep(
-                source_lang=source_lang,
-                target_lang=target_lang,
-                batch_size=batch_size
+                source_lang=source_lang, target_lang=target_lang, batch_size=batch_size
             )
-        
+
         # Create connector step
         connector_step = TranslationConnectorStep(
             parser_metadata_key=f"{parser_step.step_id}_metadata",
-            step_id="po_translation_connector"
+            step_id="po_translation_connector",
         )
-        
+
         # Create writer step
         writer_step = POFileWriterStep(output_dir=output_dir, batch_size=batch_size)
-        
+
         # Create the pipeline
         steps = [parser_step, translator_step, connector_step, writer_step]
         pipeline = Pipeline(steps=steps, name=self.name)
-        
+
         return pipeline
-    
-    def create_context(self, 
-                      source_lang: str = "en",
-                      target_lang: str = "es",
-                      translator_type: str = "google",
-                      **kwargs) -> PipelineContext:
+
+    def create_context(
+        self,
+        source_lang: str = "en",
+        target_lang: str = "es",
+        translator_type: str = "google",
+        **kwargs,
+    ) -> PipelineContext:
         """
         Create a pipeline context with the given configuration.
-        
+
         Args:
             source_lang: Source language code
             target_lang: Target language code
             translator_type: Type of translator to use
             **kwargs: Additional configuration parameters
-            
+
         Returns:
             The configured pipeline context
         """
@@ -123,31 +130,31 @@ class POTranslationPipeline(BasePipeline):
             "description": f"PO file translation from {source_lang} to {target_lang}",
             "source_language": source_lang,
             "target_language": target_lang,
-            "translator_type": translator_type
+            "translator_type": translator_type,
         }
-        
+
         # Add any additional metadata from kwargs
         metadata.update({k: v for k, v in kwargs.items() if k not in metadata})
-        
+
         return PipelineContext(metadata=metadata)
-    
+
     def prepare_inputs(self, inputs: Union[str, List[str]], **kwargs) -> List[str]:
         """
         Prepare inputs for the pipeline.
-        
+
         Args:
             inputs: File path, directory path, or list of file paths
             **kwargs: Additional configuration parameters
-            
+
         Returns:
             List of PO file paths to process
         """
         recursive = kwargs.get("recursive", True)
-        
+
         if isinstance(inputs, str):
             # Single input (file or directory)
             if os.path.isfile(inputs):
-                if not inputs.endswith('.po'):
+                if not inputs.endswith(".po"):
                     logger.warning(f"Input file is not a PO file: {inputs}")
                 return [inputs]
             elif os.path.isdir(inputs):
@@ -161,7 +168,7 @@ class POTranslationPipeline(BasePipeline):
             file_paths = []
             for input_path in inputs:
                 if os.path.isfile(input_path):
-                    if not input_path.endswith('.po'):
+                    if not input_path.endswith(".po"):
                         logger.warning(f"Input file is not a PO file: {input_path}")
                         continue
                     file_paths.append(input_path)
@@ -174,63 +181,60 @@ class POTranslationPipeline(BasePipeline):
         else:
             logger.warning(f"Invalid input type: {type(inputs)}")
             return []
-    
+
     def _find_po_files(self, directory: str, recursive: bool = True) -> List[str]:
         """
         Find all PO files in a directory.
-        
+
         Args:
             directory: Directory to search in
             recursive: Whether to search recursively
-            
+
         Returns:
             List of paths to PO files
         """
         po_files = []
-        
+
         if recursive:
             for root, _, files in os.walk(directory):
                 for file in files:
-                    if file.endswith('.po'):
+                    if file.endswith(".po"):
                         po_files.append(os.path.join(root, file))
         else:
             for file in os.listdir(directory):
-                if file.endswith('.po'):
+                if file.endswith(".po"):
                     po_files.append(os.path.join(directory, file))
-        
+
         return po_files
-    
+
     def process_outputs(self, outputs: List[str], **kwargs) -> Dict[str, str]:
         """
         Process outputs from the pipeline.
-        
+
         Args:
             outputs: List of output file paths
             **kwargs: Additional configuration parameters
-            
+
         Returns:
             Dictionary mapping input files to their corresponding output files
         """
         # Build a mapping of input to output files
         input_output_map = {}
-        
+
         if self.context:
             # Get file metadata from context
             file_metadata = self.context.get_metadata("po_file_parser_metadata") or []
-            
+
             for metadata, output_path in zip(file_metadata, outputs):
                 input_path = metadata.get("file_path", "unknown")
                 input_output_map[input_path] = output_path
-        
-        return {
-            "translated_files": outputs,
-            "input_output_map": input_output_map
-        }
-    
+
+        return {"translated_files": outputs, "input_output_map": input_output_map}
+
     def run(self, inputs: Union[str, List[str]], **kwargs) -> Dict[str, Any]:
         """
         Run the pipeline on the given inputs.
-        
+
         Args:
             inputs: File path, directory path, or list of file paths
             **kwargs: Configuration parameters:
@@ -240,7 +244,7 @@ class POTranslationPipeline(BasePipeline):
                 - translator_type: Type of translator (default: "google")
                 - batch_size: Batch size (default: 5)
                 - recursive: Whether to search directories recursively (default: True)
-                
+
         Returns:
             Dictionary with the results of the pipeline run
         """
@@ -250,7 +254,7 @@ class POTranslationPipeline(BasePipeline):
         output_dir = kwargs.get("output_dir")
         translator_type = kwargs.get("translator_type", "google")
         batch_size = kwargs.get("batch_size", 5)
-        
+
         # Build pipeline if needed
         if self.pipeline is None:
             self.pipeline = self.build_pipeline(
@@ -258,62 +262,66 @@ class POTranslationPipeline(BasePipeline):
                 target_lang=target_lang,
                 output_dir=output_dir,
                 translator_type=translator_type,
-                batch_size=batch_size
+                batch_size=batch_size,
             )
-        
+
         # Create context if needed
         if self.context is None:
             self.context = self.create_context(
                 source_lang=source_lang,
                 target_lang=target_lang,
-                translator_type=translator_type
+                translator_type=translator_type,
             )
-        
+
         # Prepare inputs
         prepared_inputs = self.prepare_inputs(inputs, **kwargs)
-        
+
         if not prepared_inputs:
             logger.warning("No PO files found to process")
             return {"translated_files": [], "input_output_map": {}}
-        
+
         # Log pipeline execution
-        logger.info(f"Running PO translation pipeline with {len(prepared_inputs)} files")
+        logger.info(
+            f"Running PO translation pipeline with {len(prepared_inputs)} files"
+        )
         logger.info(f"  Source language: {source_lang}")
         logger.info(f"  Target language: {target_lang}")
         logger.info(f"  Translator: {translator_type}")
-        
+
         # Run pipeline
         try:
             raw_outputs = self.pipeline.run(prepared_inputs, self.context)
-            
+
             # Process outputs
             processed_outputs = self.process_outputs(raw_outputs, **kwargs)
-            
+
             # Log completion
-            logger.info(f"Pipeline completed successfully: {len(raw_outputs)} files translated")
-            
+            logger.info(
+                f"Pipeline completed successfully: {len(raw_outputs)} files translated"
+            )
+
             return processed_outputs
-            
+
         except Exception as e:
             logger.error(f"Pipeline execution failed: {str(e)}")
             raise
-    
+
     def get_metrics(self) -> Dict[str, Any]:
         """
         Get execution metrics from the pipeline run.
-        
+
         Returns:
             Dictionary containing execution metrics
         """
         if self.context is None:
             return {}
-        
+
         metrics = {}
         for key, value in self.context.metrics.items():
             metrics[key] = value
-        
+
         return metrics
-    
+
     def print_metrics(self) -> None:
         """
         Print execution metrics to the console.
@@ -322,18 +330,18 @@ class POTranslationPipeline(BasePipeline):
         if not metrics:
             logger.info("No metrics available")
             return
-        
+
         logger.info(f"Pipeline '{self.name}' execution metrics:")
         for key, value in metrics.items():
             if isinstance(value, float):
                 logger.info(f"  {key}: {value:.4f}")
             else:
                 logger.info(f"  {key}: {value}")
-    
+
     def get_cli_arguments(self) -> Dict[str, Dict[str, Any]]:
         """
         Get CLI argument definitions for this pipeline.
-        
+
         Returns:
             Dictionary mapping argument names to their configurations
         """
@@ -341,38 +349,38 @@ class POTranslationPipeline(BasePipeline):
             "input": {
                 "help": "Input PO file or directory containing PO files",
                 "type": str,
-                "required": True
+                "required": True,
             },
             "source_lang": {
                 "help": "Source language code",
                 "type": str,
-                "default": "en"
+                "default": "en",
             },
             "target_lang": {
                 "help": "Target language code",
                 "type": str,
-                "default": "es"
+                "default": "es",
             },
             "output_dir": {
                 "help": "Output directory (default: same as input)",
                 "type": str,
-                "required": False
+                "required": False,
             },
             "translator_type": {
                 "help": "Type of translator to use",
                 "type": str,
                 "choices": ["google", "llm"],
-                "default": "google"
+                "default": "google",
             },
             "batch_size": {
                 "help": "Batch size for processing",
                 "type": int,
-                "default": 5
+                "default": 5,
             },
             "recursive": {
                 "help": "Search directories recursively",
-                "action": "store_true"
-            }
+                "action": "store_true",
+            },
         }
 
 
@@ -383,13 +391,13 @@ def translate_po_files(
     output_dir: Optional[str] = None,
     translator_type: str = "google",
     batch_size: int = 5,
-    recursive: bool = True
+    recursive: bool = True,
 ) -> Dict[str, Any]:
     """
     Translate PO files from one language to another.
-    
+
     This is a convenience function that creates and runs a POTranslationPipeline.
-    
+
     Args:
         po_files: Path to PO file, directory, or list of file paths
         source_lang: Source language code
@@ -398,12 +406,12 @@ def translate_po_files(
         translator_type: Type of translator to use ('google' or 'llm')
         batch_size: Batch size for processing
         recursive: Whether to search directories recursively
-        
+
     Returns:
         Dictionary with the results of the pipeline run
     """
     pipeline = POTranslationPipeline()
-    
+
     return pipeline.run(
         inputs=po_files,
         source_lang=source_lang,
@@ -411,5 +419,5 @@ def translate_po_files(
         output_dir=output_dir,
         translator_type=translator_type,
         batch_size=batch_size,
-        recursive=recursive
-    ) 
+        recursive=recursive,
+    )

--- a/pipelines/po_translation.py
+++ b/pipelines/po_translation.py
@@ -13,14 +13,17 @@ from typing import List, Optional, Dict, Any, Union
 from marovi.pipelines.core import Pipeline
 from marovi.pipelines.context import PipelineContext
 from pipelines.utils.base import BasePipeline
-from marovi.modules.steps.parsing import POFileParserStep, POFileWriterStep, TranslationConnectorStep
+from marovi.modules.steps.parsing import (
+    POFileParserStep,
+    POFileWriterStep,
+    TranslationConnectorStep,
+)
 from marovi.modules.steps.marovi_api import TranslateStep, LLMTranslateStep
 from marovi.api.core.client import MaroviAPI
 
 # Configure logging
 logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger(__name__)
 
@@ -28,19 +31,23 @@ logger = logging.getLogger(__name__)
 class POTranslationPipeline(BasePipeline):
     """
     Pipeline for translating PO files from one language to another.
-    
+
     This pipeline handles the entire process of:
     1. Parsing PO files
     2. Translating their content
     3. Saving the translations back to PO files
-    
+
     It supports both Google Translate and LLM-based translation.
     """
-    
-    def __init__(self, name: str = "po_translation_pipeline", description: str = "Translate PO files"):
+
+    def __init__(
+        self,
+        name: str = "po_translation_pipeline",
+        description: str = "Translate PO files",
+    ):
         """
         Initialize the PO translation pipeline.
-        
+
         Args:
             name: Name of the pipeline
             description: Description of the pipeline's purpose
@@ -48,17 +55,19 @@ class POTranslationPipeline(BasePipeline):
         super().__init__(name=name, description=description)
         self.pipeline = None
         self.context = None
-    
-    def build_pipeline(self, 
-                      source_lang: str = "en",
-                      target_lang: str = "es",
-                      output_dir: Optional[str] = None,
-                      translator_type: str = "google",
-                      batch_size: int = 5,
-                      **kwargs) -> Pipeline:
+
+    def build_pipeline(
+        self,
+        source_lang: str = "en",
+        target_lang: str = "es",
+        output_dir: Optional[str] = None,
+        translator_type: str = "google",
+        batch_size: int = 5,
+        **kwargs,
+    ) -> Pipeline:
         """
         Build the pipeline with the given configuration.
-        
+
         Args:
             source_lang: Source language code
             target_lang: Target language code
@@ -66,58 +75,56 @@ class POTranslationPipeline(BasePipeline):
             translator_type: Type of translator to use ('google' or 'llm')
             batch_size: Batch size for processing
             **kwargs: Additional configuration parameters
-            
+
         Returns:
             The constructed pipeline
         """
         # Create parser step
         parser_step = POFileParserStep(source_lang=source_lang, batch_size=batch_size)
-        
+
         # Create appropriate translator step based on type
         if translator_type.lower() == "llm":
             logger.info(f"Using LLM translator for {source_lang} to {target_lang}")
             translator_step = LLMTranslateStep(
-                source_lang=source_lang,
-                target_lang=target_lang,
-                batch_size=batch_size
+                source_lang=source_lang, target_lang=target_lang, batch_size=batch_size
             )
         else:  # Default to Google
             logger.info(f"Using Google translator for {source_lang} to {target_lang}")
             translator_step = TranslateStep(
-                source_lang=source_lang,
-                target_lang=target_lang,
-                batch_size=batch_size
+                source_lang=source_lang, target_lang=target_lang, batch_size=batch_size
             )
-        
+
         # Create connector step
         connector_step = TranslationConnectorStep(
             parser_metadata_key=f"{parser_step.step_id}_metadata",
-            step_id="po_translation_connector"
+            step_id="po_translation_connector",
         )
-        
+
         # Create writer step
         writer_step = POFileWriterStep(output_dir=output_dir, batch_size=batch_size)
-        
+
         # Create the pipeline
         steps = [parser_step, translator_step, connector_step, writer_step]
         pipeline = Pipeline(steps=steps, name=self.name)
-        
+
         return pipeline
-    
-    def create_context(self, 
-                      source_lang: str = "en",
-                      target_lang: str = "es",
-                      translator_type: str = "google",
-                      **kwargs) -> PipelineContext:
+
+    def create_context(
+        self,
+        source_lang: str = "en",
+        target_lang: str = "es",
+        translator_type: str = "google",
+        **kwargs,
+    ) -> PipelineContext:
         """
         Create a pipeline context with the given configuration.
-        
+
         Args:
             source_lang: Source language code
             target_lang: Target language code
             translator_type: Type of translator to use
             **kwargs: Additional configuration parameters
-            
+
         Returns:
             The configured pipeline context
         """
@@ -125,31 +132,31 @@ class POTranslationPipeline(BasePipeline):
             "description": f"PO file translation from {source_lang} to {target_lang}",
             "source_language": source_lang,
             "target_language": target_lang,
-            "translator_type": translator_type
+            "translator_type": translator_type,
         }
-        
+
         # Add any additional metadata from kwargs
         metadata.update({k: v for k, v in kwargs.items() if k not in metadata})
-        
+
         return PipelineContext(metadata=metadata)
-    
+
     def prepare_inputs(self, inputs: Union[str, List[str]], **kwargs) -> List[str]:
         """
         Prepare inputs for the pipeline.
-        
+
         Args:
             inputs: File path, directory path, or list of file paths
             **kwargs: Additional configuration parameters
-            
+
         Returns:
             List of PO file paths to process
         """
         recursive = kwargs.get("recursive", True)
-        
+
         if isinstance(inputs, str):
             # Single input (file or directory)
             if os.path.isfile(inputs):
-                if not inputs.endswith('.po'):
+                if not inputs.endswith(".po"):
                     logger.warning(f"Input file is not a PO file: {inputs}")
                 return [inputs]
             elif os.path.isdir(inputs):
@@ -163,7 +170,7 @@ class POTranslationPipeline(BasePipeline):
             file_paths = []
             for input_path in inputs:
                 if os.path.isfile(input_path):
-                    if not input_path.endswith('.po'):
+                    if not input_path.endswith(".po"):
                         logger.warning(f"Input file is not a PO file: {input_path}")
                         continue
                     file_paths.append(input_path)
@@ -176,63 +183,60 @@ class POTranslationPipeline(BasePipeline):
         else:
             logger.warning(f"Invalid input type: {type(inputs)}")
             return []
-    
+
     def _find_po_files(self, directory: str, recursive: bool = True) -> List[str]:
         """
         Find all PO files in a directory.
-        
+
         Args:
             directory: Directory to search in
             recursive: Whether to search recursively
-            
+
         Returns:
             List of paths to PO files
         """
         po_files = []
-        
+
         if recursive:
             for root, _, files in os.walk(directory):
                 for file in files:
-                    if file.endswith('.po'):
+                    if file.endswith(".po"):
                         po_files.append(os.path.join(root, file))
         else:
             for file in os.listdir(directory):
-                if file.endswith('.po'):
+                if file.endswith(".po"):
                     po_files.append(os.path.join(directory, file))
-        
+
         return po_files
-    
+
     def process_outputs(self, outputs: List[str], **kwargs) -> Dict[str, str]:
         """
         Process outputs from the pipeline.
-        
+
         Args:
             outputs: List of output file paths
             **kwargs: Additional configuration parameters
-            
+
         Returns:
             Dictionary mapping input files to their corresponding output files
         """
         # Build a mapping of input to output files
         input_output_map = {}
-        
+
         if self.context:
             # Get file metadata from context
             file_metadata = self.context.metadata.get("po_file_parser_metadata", [])
-            
+
             for metadata, output_path in zip(file_metadata, outputs):
                 input_path = metadata.get("file_path", "unknown")
                 input_output_map[input_path] = output_path
-        
-        return {
-            "translated_files": outputs,
-            "input_output_map": input_output_map
-        }
-    
+
+        return {"translated_files": outputs, "input_output_map": input_output_map}
+
     def run(self, inputs: Union[str, List[str]], **kwargs) -> Dict[str, Any]:
         """
         Run the pipeline on the given inputs.
-        
+
         Args:
             inputs: File path, directory path, or list of file paths
             **kwargs: Configuration parameters:
@@ -242,7 +246,7 @@ class POTranslationPipeline(BasePipeline):
                 - translator_type: Type of translator (default: "google")
                 - batch_size: Batch size (default: 5)
                 - recursive: Whether to search directories recursively (default: True)
-                
+
         Returns:
             Dictionary with the results of the pipeline run
         """
@@ -252,7 +256,7 @@ class POTranslationPipeline(BasePipeline):
         output_dir = kwargs.get("output_dir")
         translator_type = kwargs.get("translator_type", "google")
         batch_size = kwargs.get("batch_size", 5)
-        
+
         # Build pipeline if needed
         if self.pipeline is None:
             self.pipeline = self.build_pipeline(
@@ -260,62 +264,66 @@ class POTranslationPipeline(BasePipeline):
                 target_lang=target_lang,
                 output_dir=output_dir,
                 translator_type=translator_type,
-                batch_size=batch_size
+                batch_size=batch_size,
             )
-        
+
         # Create context if needed
         if self.context is None:
             self.context = self.create_context(
                 source_lang=source_lang,
                 target_lang=target_lang,
-                translator_type=translator_type
+                translator_type=translator_type,
             )
-        
+
         # Prepare inputs
         prepared_inputs = self.prepare_inputs(inputs, **kwargs)
-        
+
         if not prepared_inputs:
             logger.warning("No PO files found to process")
             return {"translated_files": [], "input_output_map": {}}
-        
+
         # Log pipeline execution
-        logger.info(f"Running PO translation pipeline with {len(prepared_inputs)} files")
+        logger.info(
+            f"Running PO translation pipeline with {len(prepared_inputs)} files"
+        )
         logger.info(f"  Source language: {source_lang}")
         logger.info(f"  Target language: {target_lang}")
         logger.info(f"  Translator: {translator_type}")
-        
+
         # Run pipeline
         try:
             raw_outputs = self.pipeline.run(prepared_inputs, self.context)
-            
+
             # Process outputs
             processed_outputs = self.process_outputs(raw_outputs, **kwargs)
-            
+
             # Log completion
-            logger.info(f"Pipeline completed successfully: {len(raw_outputs)} files translated")
-            
+            logger.info(
+                f"Pipeline completed successfully: {len(raw_outputs)} files translated"
+            )
+
             return processed_outputs
-            
+
         except Exception as e:
             logger.error(f"Pipeline execution failed: {str(e)}")
             raise
-    
+
     def get_metrics(self) -> Dict[str, Any]:
         """
         Get execution metrics from the pipeline run.
-        
+
         Returns:
             Dictionary containing execution metrics
         """
         if self.context is None:
             return {}
-        
+
         metrics = {}
         for key, value in self.context.metrics.items():
             metrics[key] = value
-        
+
         return metrics
-    
+
     def print_metrics(self) -> None:
         """
         Print execution metrics to the console.
@@ -324,18 +332,18 @@ class POTranslationPipeline(BasePipeline):
         if not metrics:
             logger.info("No metrics available")
             return
-        
+
         logger.info(f"Pipeline '{self.name}' execution metrics:")
         for key, value in metrics.items():
             if isinstance(value, float):
                 logger.info(f"  {key}: {value:.4f}")
             else:
                 logger.info(f"  {key}: {value}")
-    
+
     def get_cli_arguments(self) -> Dict[str, Dict[str, Any]]:
         """
         Get CLI argument definitions for this pipeline.
-        
+
         Returns:
             Dictionary mapping argument names to their configurations
         """
@@ -343,38 +351,38 @@ class POTranslationPipeline(BasePipeline):
             "input": {
                 "help": "Input PO file or directory containing PO files",
                 "type": str,
-                "required": True
+                "required": True,
             },
             "source_lang": {
                 "help": "Source language code",
                 "type": str,
-                "default": "en"
+                "default": "en",
             },
             "target_lang": {
                 "help": "Target language code",
                 "type": str,
-                "default": "es"
+                "default": "es",
             },
             "output_dir": {
                 "help": "Output directory (default: same as input)",
                 "type": str,
-                "required": False
+                "required": False,
             },
             "translator_type": {
                 "help": "Type of translator to use",
                 "type": str,
                 "choices": ["google", "llm"],
-                "default": "google"
+                "default": "google",
             },
             "batch_size": {
                 "help": "Batch size for processing",
                 "type": int,
-                "default": 5
+                "default": 5,
             },
             "recursive": {
                 "help": "Search directories recursively",
-                "action": "store_true"
-            }
+                "action": "store_true",
+            },
         }
 
 
@@ -385,13 +393,13 @@ def translate_po_files(
     output_dir: Optional[str] = None,
     translator_type: str = "google",
     batch_size: int = 5,
-    recursive: bool = True
+    recursive: bool = True,
 ) -> Dict[str, Any]:
     """
     Translate PO files from one language to another.
-    
+
     This is a convenience function that creates and runs a POTranslationPipeline.
-    
+
     Args:
         po_files: Path to PO file, directory, or list of file paths
         source_lang: Source language code
@@ -400,12 +408,12 @@ def translate_po_files(
         translator_type: Type of translator to use ('google' or 'llm')
         batch_size: Batch size for processing
         recursive: Whether to search directories recursively
-        
+
     Returns:
         Dictionary with the results of the pipeline run
     """
     pipeline = POTranslationPipeline()
-    
+
     return pipeline.run(
         inputs=po_files,
         source_lang=source_lang,
@@ -413,5 +421,5 @@ def translate_po_files(
         output_dir=output_dir,
         translator_type=translator_type,
         batch_size=batch_size,
-        recursive=recursive
+        recursive=recursive,
     )

--- a/pipelines/po_translation_pipeline.py
+++ b/pipelines/po_translation_pipeline.py
@@ -13,14 +13,17 @@ from typing import List, Optional, Dict, Any, Union
 from marovi.pipelines.core import Pipeline
 from marovi.pipelines.context import PipelineContext
 from marovi.pipelines.utils.base import BasePipeline
-from marovi.modules.steps.parsing import POFileParserStep, POFileWriterStep, TranslationConnectorStep
+from marovi.modules.steps.parsing import (
+    POFileParserStep,
+    POFileWriterStep,
+    TranslationConnectorStep,
+)
 from marovi.modules.steps.marovi_api import TranslateStep, LLMTranslateStep
 from marovi.api.core.client import MaroviAPI
 
 # Configure logging
 logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger(__name__)
 
@@ -28,19 +31,23 @@ logger = logging.getLogger(__name__)
 class POTranslationPipeline(BasePipeline):
     """
     Pipeline for translating PO files from one language to another.
-    
+
     This pipeline handles the entire process of:
     1. Parsing PO files
     2. Translating their content
     3. Saving the translations back to PO files
-    
+
     It supports both Google Translate and LLM-based translation.
     """
-    
-    def __init__(self, name: str = "po_translation_pipeline", description: str = "Translate PO files"):
+
+    def __init__(
+        self,
+        name: str = "po_translation_pipeline",
+        description: str = "Translate PO files",
+    ):
         """
         Initialize the PO translation pipeline.
-        
+
         Args:
             name: Name of the pipeline
             description: Description of the pipeline's purpose
@@ -48,17 +55,19 @@ class POTranslationPipeline(BasePipeline):
         super().__init__(name=name, description=description)
         self.pipeline = None
         self.context = None
-    
-    def build_pipeline(self, 
-                      source_lang: str = "en",
-                      target_lang: str = "es",
-                      output_dir: Optional[str] = None,
-                      translator_type: str = "google",
-                      batch_size: int = 5,
-                      **kwargs) -> Pipeline:
+
+    def build_pipeline(
+        self,
+        source_lang: str = "en",
+        target_lang: str = "es",
+        output_dir: Optional[str] = None,
+        translator_type: str = "google",
+        batch_size: int = 5,
+        **kwargs,
+    ) -> Pipeline:
         """
         Build the pipeline with the given configuration.
-        
+
         Args:
             source_lang: Source language code
             target_lang: Target language code
@@ -66,56 +75,54 @@ class POTranslationPipeline(BasePipeline):
             translator_type: Type of translator to use ('google' or 'llm')
             batch_size: Batch size for processing
             **kwargs: Additional configuration parameters
-            
+
         Returns:
             The constructed pipeline
         """
         # Create parser step
         parser_step = POFileParserStep(source_lang=source_lang, batch_size=batch_size)
-        
+
         # Create appropriate translator step based on type
         if translator_type.lower() == "llm":
             translator_step = LLMTranslateStep(
-                source_lang=source_lang,
-                target_lang=target_lang,
-                batch_size=batch_size
+                source_lang=source_lang, target_lang=target_lang, batch_size=batch_size
             )
         else:  # Default to Google
             translator_step = TranslateStep(
-                source_lang=source_lang,
-                target_lang=target_lang,
-                batch_size=batch_size
+                source_lang=source_lang, target_lang=target_lang, batch_size=batch_size
             )
-        
+
         # Create connector step
         connector_step = TranslationConnectorStep(
             parser_metadata_key=f"{parser_step.step_id}_metadata",
-            step_id="po_translation_connector"
+            step_id="po_translation_connector",
         )
-        
+
         # Create writer step
         writer_step = POFileWriterStep(output_dir=output_dir, batch_size=batch_size)
-        
+
         # Create the pipeline
         steps = [parser_step, translator_step, connector_step, writer_step]
         pipeline = Pipeline(steps=steps, name=self.name)
-        
+
         return pipeline
-    
-    def create_context(self, 
-                      source_lang: str = "en",
-                      target_lang: str = "es",
-                      translator_type: str = "google",
-                      **kwargs) -> PipelineContext:
+
+    def create_context(
+        self,
+        source_lang: str = "en",
+        target_lang: str = "es",
+        translator_type: str = "google",
+        **kwargs,
+    ) -> PipelineContext:
         """
         Create a pipeline context with the given configuration.
-        
+
         Args:
             source_lang: Source language code
             target_lang: Target language code
             translator_type: Type of translator to use
             **kwargs: Additional configuration parameters
-            
+
         Returns:
             The configured pipeline context
         """
@@ -123,31 +130,31 @@ class POTranslationPipeline(BasePipeline):
             "description": f"PO file translation from {source_lang} to {target_lang}",
             "source_language": source_lang,
             "target_language": target_lang,
-            "translator_type": translator_type
+            "translator_type": translator_type,
         }
-        
+
         # Add any additional metadata from kwargs
         metadata.update({k: v for k, v in kwargs.items() if k not in metadata})
-        
+
         return PipelineContext(metadata=metadata)
-    
+
     def prepare_inputs(self, inputs: Union[str, List[str]], **kwargs) -> List[str]:
         """
         Prepare inputs for the pipeline.
-        
+
         Args:
             inputs: File path, directory path, or list of file paths
             **kwargs: Additional configuration parameters
-            
+
         Returns:
             List of PO file paths to process
         """
         recursive = kwargs.get("recursive", True)
-        
+
         if isinstance(inputs, str):
             # Single input (file or directory)
             if os.path.isfile(inputs):
-                if not inputs.endswith('.po'):
+                if not inputs.endswith(".po"):
                     logger.warning(f"Input file is not a PO file: {inputs}")
                 return [inputs]
             elif os.path.isdir(inputs):
@@ -161,7 +168,7 @@ class POTranslationPipeline(BasePipeline):
             file_paths = []
             for input_path in inputs:
                 if os.path.isfile(input_path):
-                    if not input_path.endswith('.po'):
+                    if not input_path.endswith(".po"):
                         logger.warning(f"Input file is not a PO file: {input_path}")
                         continue
                     file_paths.append(input_path)
@@ -174,63 +181,60 @@ class POTranslationPipeline(BasePipeline):
         else:
             logger.warning(f"Invalid input type: {type(inputs)}")
             return []
-    
+
     def _find_po_files(self, directory: str, recursive: bool = True) -> List[str]:
         """
         Find all PO files in a directory.
-        
+
         Args:
             directory: Directory to search in
             recursive: Whether to search recursively
-            
+
         Returns:
             List of paths to PO files
         """
         po_files = []
-        
+
         if recursive:
             for root, _, files in os.walk(directory):
                 for file in files:
-                    if file.endswith('.po'):
+                    if file.endswith(".po"):
                         po_files.append(os.path.join(root, file))
         else:
             for file in os.listdir(directory):
-                if file.endswith('.po'):
+                if file.endswith(".po"):
                     po_files.append(os.path.join(directory, file))
-        
+
         return po_files
-    
+
     def process_outputs(self, outputs: List[str], **kwargs) -> Dict[str, str]:
         """
         Process outputs from the pipeline.
-        
+
         Args:
             outputs: List of output file paths
             **kwargs: Additional configuration parameters
-            
+
         Returns:
             Dictionary mapping input files to their corresponding output files
         """
         # Build a mapping of input to output files
         input_output_map = {}
-        
+
         if self.context:
             # Get file metadata from context
             file_metadata = self.context.get_metadata("po_file_parser_metadata") or []
-            
+
             for metadata, output_path in zip(file_metadata, outputs):
                 input_path = metadata.get("file_path", "unknown")
                 input_output_map[input_path] = output_path
-        
-        return {
-            "translated_files": outputs,
-            "input_output_map": input_output_map
-        }
-    
+
+        return {"translated_files": outputs, "input_output_map": input_output_map}
+
     def run(self, inputs: Union[str, List[str]], **kwargs) -> Dict[str, Any]:
         """
         Run the pipeline on the given inputs.
-        
+
         Args:
             inputs: File path, directory path, or list of file paths
             **kwargs: Configuration parameters:
@@ -240,7 +244,7 @@ class POTranslationPipeline(BasePipeline):
                 - translator_type: Type of translator (default: "google")
                 - batch_size: Batch size (default: 5)
                 - recursive: Whether to search directories recursively (default: True)
-                
+
         Returns:
             Dictionary with the results of the pipeline run
         """
@@ -250,7 +254,7 @@ class POTranslationPipeline(BasePipeline):
         output_dir = kwargs.get("output_dir")
         translator_type = kwargs.get("translator_type", "google")
         batch_size = kwargs.get("batch_size", 5)
-        
+
         # Build pipeline if needed
         if self.pipeline is None:
             self.pipeline = self.build_pipeline(
@@ -258,62 +262,66 @@ class POTranslationPipeline(BasePipeline):
                 target_lang=target_lang,
                 output_dir=output_dir,
                 translator_type=translator_type,
-                batch_size=batch_size
+                batch_size=batch_size,
             )
-        
+
         # Create context if needed
         if self.context is None:
             self.context = self.create_context(
                 source_lang=source_lang,
                 target_lang=target_lang,
-                translator_type=translator_type
+                translator_type=translator_type,
             )
-        
+
         # Prepare inputs
         prepared_inputs = self.prepare_inputs(inputs, **kwargs)
-        
+
         if not prepared_inputs:
             logger.warning("No PO files found to process")
             return {"translated_files": [], "input_output_map": {}}
-        
+
         # Log pipeline execution
-        logger.info(f"Running PO translation pipeline with {len(prepared_inputs)} files")
+        logger.info(
+            f"Running PO translation pipeline with {len(prepared_inputs)} files"
+        )
         logger.info(f"  Source language: {source_lang}")
         logger.info(f"  Target language: {target_lang}")
         logger.info(f"  Translator: {translator_type}")
-        
+
         # Run pipeline
         try:
             raw_outputs = self.pipeline.run(prepared_inputs, self.context)
-            
+
             # Process outputs
             processed_outputs = self.process_outputs(raw_outputs, **kwargs)
-            
+
             # Log completion
-            logger.info(f"Pipeline completed successfully: {len(raw_outputs)} files translated")
-            
+            logger.info(
+                f"Pipeline completed successfully: {len(raw_outputs)} files translated"
+            )
+
             return processed_outputs
-            
+
         except Exception as e:
             logger.error(f"Pipeline execution failed: {str(e)}")
             raise
-    
+
     def get_metrics(self) -> Dict[str, Any]:
         """
         Get execution metrics from the pipeline run.
-        
+
         Returns:
             Dictionary containing execution metrics
         """
         if self.context is None:
             return {}
-        
+
         metrics = {}
         for key, value in self.context.metrics.items():
             metrics[key] = value
-        
+
         return metrics
-    
+
     def print_metrics(self) -> None:
         """
         Print execution metrics to the console.
@@ -322,18 +330,18 @@ class POTranslationPipeline(BasePipeline):
         if not metrics:
             logger.info("No metrics available")
             return
-        
+
         logger.info(f"Pipeline '{self.name}' execution metrics:")
         for key, value in metrics.items():
             if isinstance(value, float):
                 logger.info(f"  {key}: {value:.4f}")
             else:
                 logger.info(f"  {key}: {value}")
-    
+
     def get_cli_arguments(self) -> Dict[str, Dict[str, Any]]:
         """
         Get CLI argument definitions for this pipeline.
-        
+
         Returns:
             Dictionary mapping argument names to their configurations
         """
@@ -341,38 +349,38 @@ class POTranslationPipeline(BasePipeline):
             "input": {
                 "help": "Input PO file or directory containing PO files",
                 "type": str,
-                "required": True
+                "required": True,
             },
             "source_lang": {
                 "help": "Source language code",
                 "type": str,
-                "default": "en"
+                "default": "en",
             },
             "target_lang": {
                 "help": "Target language code",
                 "type": str,
-                "default": "es"
+                "default": "es",
             },
             "output_dir": {
                 "help": "Output directory (default: same as input)",
                 "type": str,
-                "required": False
+                "required": False,
             },
             "translator_type": {
                 "help": "Type of translator to use",
                 "type": str,
                 "choices": ["google", "llm"],
-                "default": "google"
+                "default": "google",
             },
             "batch_size": {
                 "help": "Batch size for processing",
                 "type": int,
-                "default": 5
+                "default": 5,
             },
             "recursive": {
                 "help": "Search directories recursively",
-                "action": "store_true"
-            }
+                "action": "store_true",
+            },
         }
 
 
@@ -383,13 +391,13 @@ def translate_po_files(
     output_dir: Optional[str] = None,
     translator_type: str = "google",
     batch_size: int = 5,
-    recursive: bool = True
+    recursive: bool = True,
 ) -> Dict[str, Any]:
     """
     Translate PO files from one language to another.
-    
+
     This is a convenience function that creates and runs a POTranslationPipeline.
-    
+
     Args:
         po_files: Path to PO file, directory, or list of file paths
         source_lang: Source language code
@@ -398,12 +406,12 @@ def translate_po_files(
         translator_type: Type of translator to use ('google' or 'llm')
         batch_size: Batch size for processing
         recursive: Whether to search directories recursively
-        
+
     Returns:
         Dictionary with the results of the pipeline run
     """
     pipeline = POTranslationPipeline()
-    
+
     return pipeline.run(
         inputs=po_files,
         source_lang=source_lang,
@@ -411,5 +419,5 @@ def translate_po_files(
         output_dir=output_dir,
         translator_type=translator_type,
         batch_size=batch_size,
-        recursive=recursive
+        recursive=recursive,
     )

--- a/pipelines/runs/po_translation.py
+++ b/pipelines/runs/po_translation.py
@@ -18,8 +18,7 @@ from marovi.pipelines.po_translation import POTranslationPipeline, translate_po_
 
 # Configure logging
 logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger(__name__)
 
@@ -27,36 +26,38 @@ logger = logging.getLogger(__name__)
 def example_direct_usage(
     input_file: str = "data/wiki_pages/marovi/Welcome/page-Welcome_en.po",
     output_dir: str = "data/translations",
-    target_lang: str = "es"
+    target_lang: str = "es",
 ) -> None:
     """
     Example showing direct usage of the POTranslationPipeline class.
-    
+
     Args:
         input_file: Path to a PO file to translate
         output_dir: Directory to save translated files
         target_lang: Target language code
     """
     logger.info("=== Starting direct pipeline usage example ===")
-    
+
     # Validate input file exists
     if not os.path.exists(input_file):
         logger.error(f"Input file not found: {input_file}")
         return
-    
+
     # Create output directory if it doesn't exist
     os.makedirs(output_dir, exist_ok=True)
-    
+
     try:
         # Method 1: Using the convenience function
         logger.info("Method 1: Using the translate_po_files convenience function")
         es_result = translate_po_files(
             po_files=input_file,
             target_lang=target_lang,  # Spanish
-            output_dir=output_dir
+            output_dir=output_dir,
         )
-        logger.info(f"Translated {len(es_result['translated_files'])} file(s) to {target_lang}")
-        
+        logger.info(
+            f"Translated {len(es_result['translated_files'])} file(s) to {target_lang}"
+        )
+
         # Method 2: Creating and running the pipeline directly
         logger.info("Method 2: Creating and running the pipeline directly")
         pipeline = POTranslationPipeline()
@@ -64,72 +65,76 @@ def example_direct_usage(
             inputs=input_file,
             source_lang="en",
             target_lang="fr",  # French
-            output_dir=output_dir
+            output_dir=output_dir,
         )
         logger.info(f"Translated {len(fr_result['translated_files'])} file(s) to fr")
-        
+
     except Exception as e:
         logger.error(f"Pipeline execution failed: {str(e)}")
         import traceback
+
         traceback.print_exc()
 
 
 def example_runner_usage(
     input_file: str = "data/wiki_pages/marovi/Welcome/page-Welcome_en.po",
-    output_dir: str = "data/translations"
+    output_dir: str = "data/translations",
 ) -> None:
     """
     Example showing usage of the PipelineRunner with the PO translation pipeline.
-    
+
     Args:
         input_file: Path to a PO file to translate
         output_dir: Directory to save translated files
     """
     logger.info("=== Starting runner-based pipeline usage example ===")
-    
+
     # Validate input file exists
     if not os.path.exists(input_file):
         logger.error(f"Input file not found: {input_file}")
         return
-    
+
     # Create output directory if it doesn't exist
     os.makedirs(output_dir, exist_ok=True)
-    
+
     try:
         # Import the PipelineRunner
         from marovi.pipelines.utils.runner import PipelineRunner
-        
+
         # Create a runner instance
         runner = PipelineRunner()
-        
+
         # List available pipelines
         logger.info("Available pipelines:")
         pipelines = runner.list_pipelines()
         for pipeline_name in pipelines:
             logger.info(f"  - {pipeline_name}")
-        
+
         # Get pipeline info
         pipeline_info = runner.get_pipeline_info()
         logger.info("Pipeline descriptions:")
         for name, info in pipeline_info.items():
             logger.info(f"  - {name}: {info['description']}")
-        
+
         # Run the PO translation pipeline
         result = runner.run_pipeline(
             pipeline_name="po_translation",
             inputs=input_file,
             target_lang="de",  # German
-            output_dir=output_dir
+            output_dir=output_dir,
         )
-        
+
         if result:
-            logger.info(f"Runner-based pipeline translated {len(result['translated_files'])} file(s)")
+            logger.info(
+                f"Runner-based pipeline translated {len(result['translated_files'])} file(s)"
+            )
         else:
             logger.error("Runner-based pipeline execution failed")
-            
+
     except Exception as e:
         logger.error(f"Runner-based pipeline execution failed: {str(e)}")
         import traceback
+
         traceback.print_exc()
 
 
@@ -137,24 +142,22 @@ def main() -> None:
     """
     Main function to run the examples.
     """
-    parser = argparse.ArgumentParser(
-        description="Run PO Translation Pipeline examples"
-    )
+    parser = argparse.ArgumentParser(description="Run PO Translation Pipeline examples")
     parser.add_argument(
-        "--input", 
-        type=str, 
+        "--input",
+        type=str,
         default="data/wiki_pages/marovi/Welcome/page-Welcome_en.po",
-        help="Path to a PO file to translate"
+        help="Path to a PO file to translate",
     )
     parser.add_argument(
         "--output-dir",
         type=str,
         default="data/translations",
-        help="Directory to save translated files"
+        help="Directory to save translated files",
     )
-    
+
     args = parser.parse_args()
-    
+
     # Run both examples
     example_direct_usage(args.input, args.output_dir)
     example_runner_usage(args.input, args.output_dir)

--- a/pipelines/utils/__init__.py
+++ b/pipelines/utils/__init__.py
@@ -6,6 +6,4 @@ This package provides utilities for running and managing pipelines.
 
 from pipelines.utils.runner import PipelineRunner
 
-__all__ = [
-    'PipelineRunner'
-]
+__all__ = ["PipelineRunner"]

--- a/pipelines/utils/base.py
+++ b/pipelines/utils/base.py
@@ -19,15 +19,15 @@ logger = logging.getLogger(__name__)
 class BasePipeline(ABC):
     """
     Abstract base class for pipeline implementations.
-    
+
     This class defines the interface that all pipeline implementations must follow,
     ensuring a consistent API for programmatic and CLI usage.
     """
-    
+
     def __init__(self, name: str = "unnamed_pipeline", description: str = ""):
         """
         Initialize a pipeline with name and description.
-        
+
         Args:
             name: Name of the pipeline
             description: Description of the pipeline's purpose
@@ -35,30 +35,30 @@ class BasePipeline(ABC):
         self.name = name
         self.description = description
         self.metrics = {}
-    
+
     @abstractmethod
     def run(self, inputs: Any, **kwargs) -> Any:
         """
         Run the pipeline on the given inputs.
-        
+
         Args:
             inputs: Input data for the pipeline
             **kwargs: Additional configuration parameters
-            
+
         Returns:
             Results of the pipeline run
         """
         raise NotImplementedError
-    
+
     def get_metrics(self) -> Dict[str, Any]:
         """
         Get metrics from the last pipeline run.
-        
+
         Returns:
             Dictionary of pipeline metrics
         """
         return self.metrics
-    
+
     def print_metrics(self) -> None:
         """
         Print metrics from the last pipeline run.
@@ -66,18 +66,18 @@ class BasePipeline(ABC):
         if not self.metrics:
             logger.info("No metrics available.")
             return
-        
+
         logger.info(f"Metrics for {self.name}:")
         for key, value in self.metrics.items():
             if isinstance(value, float):
                 logger.info(f"  {key}: {value:.4f}")
             else:
                 logger.info(f"  {key}: {value}")
-    
+
     def get_cli_arguments(self) -> Dict[str, Dict[str, Any]]:
         """
         Get the CLI arguments for this pipeline.
-        
+
         Returns:
             Dictionary mapping argument names to their configurations
         """
@@ -85,6 +85,6 @@ class BasePipeline(ABC):
             "input": {
                 "help": "Input file or directory path",
                 "type": str,
-                "required": True
+                "required": True,
             }
-        } 
+        }

--- a/pipelines/utils/cli.py
+++ b/pipelines/utils/cli.py
@@ -17,8 +17,7 @@ from marovi.pipelines.utils.runner import PipelineRunner
 
 # Configure logging
 logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger(__name__)
 
@@ -26,7 +25,7 @@ logger = logging.getLogger(__name__)
 def setup_parser() -> argparse.ArgumentParser:
     """
     Set up the argument parser for the CLI.
-    
+
     Returns:
         Configured argument parser
     """
@@ -43,44 +42,44 @@ Examples:
   
   # Run a pipeline
   python -m marovi.pipelines.cli run po_translation --input path/to/file.po --target_lang es
-"""
+""",
     )
-    
+
     subparsers = parser.add_subparsers(dest="command", help="Command to execute")
     subparsers.required = True
-    
+
     # List command
     list_parser = subparsers.add_parser("list", help="List available pipelines")
-    
+
     # Info command
     info_parser = subparsers.add_parser("info", help="Get information about a pipeline")
     info_parser.add_argument("pipeline", help="Name of the pipeline")
-    
+
     # Run command
     run_parser = subparsers.add_parser("run", help="Run a pipeline")
     run_parser.add_argument("pipeline", help="Name of the pipeline to run")
-    
+
     # The run command will have additional arguments added dynamically
     # when the pipeline is selected
-    
+
     return parser
 
 
 def add_pipeline_arguments(parser: argparse.ArgumentParser, pipeline_name: str) -> None:
     """
     Add pipeline-specific arguments to the parser.
-    
+
     Args:
         parser: Argument parser to add arguments to
         pipeline_name: Name of the pipeline
     """
     runner = PipelineRunner()
     pipeline = runner.create_pipeline(pipeline_name)
-    
+
     if pipeline is None:
         logger.error(f"Pipeline not found: {pipeline_name}")
         return
-    
+
     for arg_name, arg_config in pipeline.get_cli_arguments().items():
         # Extract argument configuration
         help_text = arg_config.get("help", f"Argument {arg_name}")
@@ -89,31 +88,31 @@ def add_pipeline_arguments(parser: argparse.ArgumentParser, pipeline_name: str) 
         choices = arg_config.get("choices", None)
         default = arg_config.get("default", None)
         action = arg_config.get("action", None)
-        
+
         # Build argument
         args = []
         if len(arg_name) == 1:
             args.append(f"-{arg_name}")
         else:
             args.append(f"--{arg_name}")
-        
+
         kwargs = {"help": help_text}
-        
+
         if arg_type:
             kwargs["type"] = arg_type
-        
+
         if required:
             kwargs["required"] = required
-        
+
         if choices:
             kwargs["choices"] = choices
-        
+
         if default is not None:
             kwargs["default"] = default
-        
+
         if action:
             kwargs["action"] = action
-        
+
         # Add the argument
         parser.add_argument(*args, **kwargs)
 
@@ -124,11 +123,11 @@ def list_pipelines() -> None:
     """
     runner = PipelineRunner()
     pipeline_info = runner.get_pipeline_info()
-    
+
     if not pipeline_info:
         print("No pipelines found")
         return
-    
+
     print("Available pipelines:")
     for name, info in pipeline_info.items():
         print(f"  {name}: {info['description']}")
@@ -137,33 +136,33 @@ def list_pipelines() -> None:
 def show_pipeline_info(pipeline_name: str) -> None:
     """
     Show detailed information about a pipeline.
-    
+
     Args:
         pipeline_name: Name of the pipeline
     """
     runner = PipelineRunner()
     pipeline = runner.create_pipeline(pipeline_name)
-    
+
     if pipeline is None:
         print(f"Pipeline not found: {pipeline_name}")
         return
-    
+
     print(f"Pipeline: {pipeline.name}")
     print(f"Description: {pipeline.description}")
     print("\nArguments:")
-    
+
     for arg_name, arg_config in pipeline.get_cli_arguments().items():
         help_text = arg_config.get("help", "")
         required = arg_config.get("required", False)
         default = arg_config.get("default", None)
-        
+
         # Format argument display
         arg_str = f"  --{arg_name}"
         if required:
             arg_str += " (required)"
         if default is not None:
             arg_str += f" [default: {default}]"
-        
+
         print(arg_str)
         print(f"    {help_text}")
 
@@ -171,29 +170,29 @@ def show_pipeline_info(pipeline_name: str) -> None:
 def run_pipeline(args: argparse.Namespace) -> None:
     """
     Run a pipeline with the given arguments.
-    
+
     Args:
         args: Command-line arguments
     """
     pipeline_name = args.pipeline
-    
+
     # Get all arguments as a dictionary
     arg_dict = vars(args)
-    
+
     # Remove the command and pipeline arguments
     arg_dict.pop("command")
     arg_dict.pop("pipeline")
-    
+
     # Get input files or directories
     inputs = arg_dict.pop("input", None)
     if inputs is None:
         logger.error("No input specified")
         return
-    
+
     # Run the pipeline
     runner = PipelineRunner()
     result = runner.run_pipeline(pipeline_name, inputs, **arg_dict)
-    
+
     if result is not None:
         logger.info(f"Pipeline {pipeline_name} completed successfully")
     else:
@@ -205,30 +204,30 @@ def main() -> None:
     Main entry point for the CLI.
     """
     parser = setup_parser()
-    
+
     # Parse initial arguments to get the command and pipeline
     args, unknown = parser.parse_known_args()
-    
+
     # If the command is 'run', add pipeline-specific arguments
     if args.command == "run":
         pipeline_name = args.pipeline
-        
+
         # Create a new parser with pipeline-specific arguments
         run_parser = argparse.ArgumentParser(
             description=f"Run {pipeline_name} pipeline",
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         )
-        
+
         # Add pipeline-specific arguments
         add_pipeline_arguments(run_parser, pipeline_name)
-        
+
         # Parse again with the updated parser
         run_args = run_parser.parse_args(unknown)
-        
+
         # Combine the arguments
         for key, value in vars(run_args).items():
             setattr(args, key, value)
-    
+
     # Execute the appropriate command
     if args.command == "list":
         list_pipelines()
@@ -246,4 +245,4 @@ if __name__ == "__main__":
         sys.exit(1)
     except Exception as e:
         logger.exception("An error occurred")
-        sys.exit(1) 
+        sys.exit(1)

--- a/pipelines/utils/runner.py
+++ b/pipelines/utils/runner.py
@@ -23,27 +23,27 @@ logger = logging.getLogger(__name__)
 class PipelineRunner:
     """
     A runner for dynamically loading and executing pipelines.
-    
+
     This class provides functionality to discover, load, and run pipeline
     implementations by name, making it easy to execute pipelines both
     programmatically and from the command line.
     """
-    
+
     def __init__(self, pipelines_package: str = "marovi.pipelines"):
         """
         Initialize the pipeline runner.
-        
+
         Args:
             pipelines_package: Base package where pipeline implementations are located
         """
         self.pipelines_package = pipelines_package
         self.pipeline_registry: Dict[str, Type[BasePipeline]] = {}
         self.discover_pipelines()
-    
+
     def discover_pipelines(self) -> None:
         """
         Discover available pipeline implementations.
-        
+
         This method searches for pipeline implementations in the specified
         package and registers them by name.
         """
@@ -51,97 +51,98 @@ class PipelineRunner:
         try:
             package = importlib.import_module(self.pipelines_package)
         except ImportError:
-            logger.error(f"Could not import pipelines package: {self.pipelines_package}")
+            logger.error(
+                f"Could not import pipelines package: {self.pipelines_package}"
+            )
             return
-        
+
         # Get the package directory
         if not hasattr(package, "__path__"):
             logger.error(f"Package {self.pipelines_package} is not a directory package")
             return
-        
+
         package_dir = package.__path__[0]
-        
+
         # Find Python modules in the package
         for filename in os.listdir(package_dir):
             if not filename.endswith(".py") or filename.startswith("_"):
                 continue
-            
+
             module_name = filename[:-3]  # Remove .py extension
             full_module_name = f"{self.pipelines_package}.{module_name}"
-            
+
             try:
                 module = importlib.import_module(full_module_name)
-                
+
                 # Look for pipeline classes in the module
                 for item_name in dir(module):
                     item = getattr(module, item_name)
-                    
+
                     # Check if it's a pipeline class
-                    if (isinstance(item, type) and 
-                        issubclass(item, BasePipeline) and 
-                        item is not BasePipeline):
-                        
+                    if (
+                        isinstance(item, type)
+                        and issubclass(item, BasePipeline)
+                        and item is not BasePipeline
+                    ):
+
                         # Register the pipeline
                         pipeline_name = item_name.lower().replace("pipeline", "")
                         self.pipeline_registry[pipeline_name] = item
                         logger.debug(f"Registered pipeline: {pipeline_name}")
-            
+
             except (ImportError, AttributeError) as e:
                 logger.warning(f"Error loading module {full_module_name}: {e}")
-    
+
     def get_pipeline_class(self, name: str) -> Optional[Type[BasePipeline]]:
         """
         Get a pipeline class by name.
-        
+
         Args:
             name: Name of the pipeline
-            
+
         Returns:
             The pipeline class if found, None otherwise
         """
         # Normalize the name
         normalized_name = name.lower().replace("pipeline", "").replace("_", "")
-        
+
         # Try exact match first
         if normalized_name in self.pipeline_registry:
             return self.pipeline_registry[normalized_name]
-        
+
         # Try partial match
         for key, pipeline_class in self.pipeline_registry.items():
             if normalized_name in key or key in normalized_name:
                 return pipeline_class
-        
+
         return None
-    
+
     def create_pipeline(self, name: str, **kwargs) -> Optional[BasePipeline]:
         """
         Create a pipeline instance by name.
-        
+
         Args:
             name: Name of the pipeline
             **kwargs: Additional arguments for the pipeline constructor
-            
+
         Returns:
             The pipeline instance if found, None otherwise
         """
         pipeline_class = self.get_pipeline_class(name)
         if pipeline_class is None:
             return None
-        
+
         return pipeline_class(**kwargs)
-    
-    def run_pipeline(self, 
-                     pipeline_name: str, 
-                     inputs: Any, 
-                     **kwargs) -> Any:
+
+    def run_pipeline(self, pipeline_name: str, inputs: Any, **kwargs) -> Any:
         """
         Run a pipeline by name.
-        
+
         Args:
             pipeline_name: Name of the pipeline to run
             inputs: Inputs for the pipeline
             **kwargs: Additional arguments for the pipeline run
-            
+
         Returns:
             The pipeline outputs if successful, None otherwise
         """
@@ -150,38 +151,42 @@ class PipelineRunner:
         if pipeline is None:
             logger.error(f"Pipeline not found: {pipeline_name}")
             return None
-        
+
         # Run the pipeline
         start_time = time.time()
         try:
             outputs = pipeline.run(inputs, **kwargs)
             end_time = time.time()
-            logger.info(f"Pipeline {pipeline_name} completed in {end_time - start_time:.2f} seconds")
-            
+            logger.info(
+                f"Pipeline {pipeline_name} completed in {end_time - start_time:.2f} seconds"
+            )
+
             # Print metrics
             pipeline.print_metrics()
-            
+
             return outputs
-            
+
         except Exception as e:
             end_time = time.time()
-            logger.error(f"Pipeline {pipeline_name} failed after {end_time - start_time:.2f} seconds")
+            logger.error(
+                f"Pipeline {pipeline_name} failed after {end_time - start_time:.2f} seconds"
+            )
             logger.exception(e)
             return None
-    
+
     def list_pipelines(self) -> List[str]:
         """
         Get a list of available pipeline names.
-        
+
         Returns:
             List of pipeline names
         """
         return list(self.pipeline_registry.keys())
-    
+
     def get_pipeline_info(self) -> Dict[str, Dict[str, str]]:
         """
         Get information about all available pipelines.
-        
+
         Returns:
             Dictionary mapping pipeline names to their info
         """
@@ -189,9 +194,6 @@ class PipelineRunner:
         for name, pipeline_class in self.pipeline_registry.items():
             # Create a temporary instance to get the description
             pipeline = pipeline_class()
-            info[name] = {
-                "name": pipeline.name,
-                "description": pipeline.description
-            }
-        
+            info[name] = {"name": pipeline.name, "description": pipeline.description}
+
         return info


### PR DESCRIPTION
## Summary
- run black formatting on pipeline-related modules
- keep example and pipeline code for translating .po files

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685bf9d553d88320a2531bca805fbb68