### PR TITLE
Add minimal pytest framework and PO translation test

### DIFF
--- a/marovi/tests/test_config.py
+++ b/marovi/tests/test_config.py
@@ -1,0 +1,37 @@
+import importlib
+from pathlib import Path
+
+
+def _reload_config(monkeypatch, data_path=None, use_db=None, db_url=None):
+    env = {
+        "DATA_STORAGE_PATH": data_path,
+        "USE_DATABASE": use_db,
+        "DATABASE_URL": db_url,
+    }
+    for key, value in env.items():
+        if value is None:
+            monkeypatch.delenv(key, raising=False)
+        else:
+            monkeypatch.setenv(key, str(value))
+    import marovi.config as cfg
+    return importlib.reload(cfg)
+
+
+def test_config_defaults(monkeypatch):
+    cfg = _reload_config(monkeypatch)
+    expected = Path(cfg.__file__).resolve().parent.parent / "data"
+    assert cfg.BASE_PATH == expected
+    assert cfg.USE_DATABASE is False
+    assert cfg.DATABASE_URL == "sqlite:///database/papers.db"
+
+
+def test_config_environment_overrides(monkeypatch, tmp_path):
+    cfg = _reload_config(
+        monkeypatch,
+        data_path=tmp_path,
+        use_db="true",
+        db_url="postgresql://user/db",
+    )
+    assert cfg.BASE_PATH == tmp_path.resolve()
+    assert cfg.USE_DATABASE is True
+    assert cfg.DATABASE_URL == "postgresql://user/db"

--- a/marovi/tests/test_pipeline_context.py
+++ b/marovi/tests/test_pipeline_context.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import json
+
+from marovi.pipelines.context import PipelineContext
+
+
+def test_context_state_and_checkpoint(tmp_path):
+    ctx = PipelineContext(metadata={"doc": 1}, checkpoint_dir=str(tmp_path))
+    ctx.log_step("step1", [1], [2])
+    ctx.add_metadata("extra", "value")
+    ctx.update_state("step1", [2], {"info": "x"})
+
+    assert ctx.get_state("step1")["outputs"] == [2]
+    assert ctx.get_outputs("step1") == [2]
+
+    ctx.log_metrics({"loss": 0.5}, step=1)
+    assert ctx.get_metric("loss") == 0.5
+
+    ctx.register_artifact("model", "model.bin", {"size": 1})
+    checkpoint = ctx.save_checkpoint("test")
+    assert Path(checkpoint).exists()
+
+    new_ctx = PipelineContext(checkpoint_dir=str(tmp_path))
+    new_ctx.load_checkpoint(checkpoint)
+    assert new_ctx.get_outputs("step1") == [2]
+
+    json_str = ctx.to_json()
+    restored = PipelineContext.from_json(json_str)
+    assert restored.metadata["doc"] == 1
+
+    summary = ctx.get_summary()
+    assert summary["steps_executed"] == 1

--- a/marovi/tests/test_pipeline_core.py
+++ b/marovi/tests/test_pipeline_core.py
@@ -1,0 +1,61 @@
+from marovi.pipelines.core import PipelineStep, Pipeline, BranchingPipeline
+from marovi.pipelines.context import PipelineContext
+
+
+class MultiplyStep(PipelineStep[int, int]):
+    def __init__(self, factor):
+        super().__init__(step_id="mult")
+        self.factor = factor
+
+    def process(self, inputs, context):
+        return [i * self.factor for i in inputs]
+
+
+class AddStep(PipelineStep[int, int]):
+    def __init__(self, add):
+        super().__init__(step_id="add")
+        self.add = add
+
+    def process(self, inputs, context):
+        return [i + self.add for i in inputs]
+
+
+class FlakyStep(PipelineStep[int, int]):
+    def __init__(self, fail_times=1):
+        super().__init__(step_id="flaky")
+        self.fail_times = fail_times
+
+    def process(self, inputs, context):
+        if self.fail_times > 0:
+            self.fail_times -= 1
+            raise ValueError("fail")
+        return inputs
+
+
+def test_run_with_retries():
+    ctx = PipelineContext()
+    step = FlakyStep(fail_times=1)
+    assert step.run_with_retries([1], ctx) == [1]
+
+
+def test_pipeline_execution(tmp_path):
+    ctx = PipelineContext(checkpoint_dir=str(tmp_path))
+    pipeline = Pipeline([
+        MultiplyStep(2),
+        AddStep(3),
+    ], name="calc", checkpoint_dir=str(tmp_path))
+    outputs = pipeline.run([1, 2], ctx)
+    assert outputs == [5, 7]
+    cp = tmp_path / f"{ctx.context_id}_calc_after_add.json"
+    assert cp.exists()
+
+
+def test_branching_pipeline(tmp_path):
+    branches = {
+        "main": [MultiplyStep(2)],
+        "alt": [AddStep(1)],
+    }
+    pipeline = BranchingPipeline(branches, checkpoint_dir=str(tmp_path))
+    ctx = PipelineContext(checkpoint_dir=str(tmp_path))
+    assert pipeline.run([2], ctx) == [4]
+    assert pipeline.run_branch("alt", [2], ctx) == [3]

--- a/marovi/tests/test_pipeline_steps.py
+++ b/marovi/tests/test_pipeline_steps.py
@@ -1,0 +1,32 @@
+from marovi.pipelines.steps import ConditionalStep, CheckpointStep
+from marovi.pipelines.context import PipelineContext
+from marovi.pipelines.core import PipelineStep
+
+
+class IdentityStep(PipelineStep[int, int]):
+    def __init__(self, step_id="identity"):
+        super().__init__(step_id=step_id)
+
+    def process(self, inputs, context):
+        return inputs
+
+
+def test_conditional_step():
+    ctx = PipelineContext()
+    true_step = IdentityStep("true")
+    false_step = IdentityStep("false")
+    step = ConditionalStep(lambda x: x % 2 == 0, true_step, false_step, step_id="cond")
+    outputs = step.process([1, 2, 3], ctx)
+    # true branch processed even numbers first, then false branch
+    assert outputs == [2, 1, 3]
+
+
+def test_checkpoint_step(tmp_path):
+    ctx = PipelineContext(checkpoint_dir=str(tmp_path))
+    step = CheckpointStep(checkpoint_name="chk")
+    data = [1, 2]
+    outputs = step.process(data, ctx)
+    assert outputs == data
+    assert ctx.get_outputs("chk") == data
+    checkpoint_path = tmp_path / f"{ctx.context_id}_chk.json"
+    assert checkpoint_path.exists()

--- a/marovi/tests/test_po_parser.py
+++ b/marovi/tests/test_po_parser.py
@@ -1,0 +1,125 @@
+"""Tests for the PO translation workflow.
+
+This test includes a minimal stub for the ``polib`` package so that it can
+run in environments where the real dependency is unavailable.  The stub
+implements just enough functionality for ``POParser`` to operate.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Provide a minimal ``polib`` stub if the real library is unavailable
+# ---------------------------------------------------------------------------
+
+try:  # pragma: no cover - exercised only when polib is available
+    import polib as polib_stub  # type: ignore
+except Exception:  # pragma: no cover - executed when polib is missing
+    polib_stub = types.ModuleType("polib")
+
+    class POEntry:
+        def __init__(self, msgid: str, msgstr: str = ""):
+            self.msgid = msgid
+            self.msgstr = msgstr
+            self.obsolete = False
+
+    class POFile(list):
+        def untranslated_entries(self):
+            return [e for e in self if not e.msgstr]
+
+        def translated_entries(self):
+            return [e for e in self if e.msgstr]
+
+        def fuzzy_entries(self):
+            return []
+
+        def save(self, path: str):
+            Path(path).write_text("")
+
+    def _parse_content(content: str) -> POFile:
+        entries = []
+        lines = [line.strip() for line in content.splitlines() if line.strip()]
+        i = 0
+        while i < len(lines):
+            if lines[i].startswith("msgid"):
+                msgid = lines[i][6:].strip().strip('"')
+                if msgid == "":  # skip header entry
+                    i += 2
+                    continue
+                if i + 1 < len(lines) and lines[i + 1].startswith("msgstr"):
+                    msgstr = lines[i + 1][7:].strip().strip('"')
+                    entries.append(POEntry(msgid, msgstr))
+                    i += 2
+                else:
+                    i += 1
+            else:
+                i += 1
+        return POFile(entries)
+
+    def pofile(path_or_content: str) -> POFile:
+        if Path(path_or_content).exists():
+            content = Path(path_or_content).read_text()
+        else:
+            content = path_or_content
+        return _parse_content(content)
+
+    polib_stub.POEntry = POEntry
+    polib_stub.POFile = POFile
+    polib_stub.pofile = pofile
+    sys.modules.setdefault("polib", polib_stub)
+
+
+# ---------------------------------------------------------------------------
+# Import the parser under test
+# ---------------------------------------------------------------------------
+
+from marovi.modules.parsing.po_parser import POParser
+
+
+class _DummyService:
+    """Minimal translation service used for testing.
+
+    It simply appends the target language code to each piece of text.
+    """
+
+    def translate(self, text, source_language, target_language):
+        return [f"{t}_{target_language}" for t in text]
+
+
+def test_po_translation_workflow(tmp_path):
+    """Ensure that POParser can load, translate, and compile a PO file."""
+
+    po_content = (
+        'msgid ""\n'
+        'msgstr ""\n\n'
+        'msgid "Hello"\n'
+        'msgstr ""\n\n'
+        'msgid "World"\n'
+        'msgstr ""\n'
+    )
+
+    po_file = tmp_path / "messages.po"
+    po_file.write_text(po_content)
+
+    parser = POParser()
+    parser.load_from_file(str(po_file))
+    parser.set_languages("en", "es")
+
+    service = _DummyService()
+    translations = parser.auto_translate(service)
+
+    assert translations == ["Hello_es", "World_es"]
+    assert parser.parse() == {"Hello": "Hello_es", "World": "World_es"}
+
+    compiled = parser.compile_translations()
+    assert "Hello_es" in compiled
+    assert "World_es" in compiled
+
+    stats = parser.get_stats()
+    assert stats["translated"] == 2
+    assert stats["untranslated"] == 0
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ google = "^3.0.0"
 requests = "^2.32.3"
 google-generativeai = "^0.8.5"
 
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.0"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api" 


### PR DESCRIPTION
## Summary
- enable pytest as a dev dependency
- add a unit test covering the PO translation workflow with a stubbed translation service
- introduce comprehensive tests for configuration handling, pipeline context, pipeline execution, and specialized pipeline steps

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68985344adf48320a65aea168fb65574