### PR TITLE
Add pipeline to publish arXiv papers to wiki

### DIFF
--- a/marovi/api/custom/__init__.py
+++ b/marovi/api/custom/__init__.py
@@ -6,12 +6,14 @@ This module provides custom endpoints that extend the Marovi API functionality.
 
 # Import from schemas module, not directly from schemas.py which is deleted
 from .schemas import (
-    TranslationRequest, 
+    TranslationRequest,
     TranslationResponse,
     FormatConversionRequest,
     FormatConversionResponse,
     SummarizationRequest,
     SummarizationResponse,
+    CleanTextRequest,
+    CleanTextResponse,
     SupportedFormat,
     SummaryStyle
 )
@@ -34,6 +36,9 @@ from .endpoints.summarize import (
     SummarizationError
 )
 
+# Import text cleaner
+from .endpoints.clean_text import CleanText
+
 # Import registry functionality
 from .core.registry import (
     register_endpoint,
@@ -49,11 +54,14 @@ __all__ = [
     # Format converter
     "FormatConverter",
     "FormatConversionError",
-    
+
     # Summarizer
     "Summarizer",
     "SummarizationError",
-    
+
+    # Text cleaner
+    "CleanText",
+
     # Registry functionality
     "register_endpoint",
     "register_default_endpoints",
@@ -66,6 +74,8 @@ __all__ = [
     "FormatConversionResponse",
     "SummarizationRequest",
     "SummarizationResponse",
+    "CleanTextRequest",
+    "CleanTextResponse",
     "SupportedFormat",
     "SummaryStyle"
 ]

--- a/marovi/api/custom/core/registry.py
+++ b/marovi/api/custom/core/registry.py
@@ -210,3 +210,12 @@ def register_default_endpoints(registry=None):
         logger.debug("Registered Summarizer endpoint")
     except (ImportError, Exception) as e:
         logger.warning(f"Failed to register Summarizer endpoint: {str(e)}")
+
+    # Register CleanText endpoint
+    try:
+        from ..endpoints.clean_text import CleanText
+        cleaner = CleanText()
+        registry.register_endpoint("clean_text", cleaner)
+        logger.debug("Registered CleanText endpoint")
+    except (ImportError, Exception) as e:
+        logger.warning(f"Failed to register CleanText endpoint: {str(e)}")

--- a/marovi/api/custom/prompts/clean_text.jinja
+++ b/marovi/api/custom/prompts/clean_text.jinja
@@ -2,6 +2,9 @@ You are an expert in text cleaning and formatting. Your task is to clean up the 
 
 {% if format == "wiki" %}
 # Cleaning Instructions for Wiki Format
+- The text originates from HTML converted with Pandoc. Ensure the final output is valid MediaWiki syntax.
+- Preserve **all** original English prose and mathematical content; do not translate or remove any material.
+- Ensure equations remain intact and wrapped in proper `<math>` tags when needed.
 - Remove any HTML tags or syntax that was not properly converted
 - Fix formatting issues with headers, lists, tables, and other wiki elements
 - Remove any double brackets from links like [[[[link]]]] -> [[link]]

--- a/marovi/api/custom/prompts/prompt_registry.yaml
+++ b/marovi/api/custom/prompts/prompt_registry.yaml
@@ -22,6 +22,16 @@ templates:
     output_fields:
       schema: "format_conversion.FormatConversionResponse"
 
+  # Text Cleaning Templates
+  clean_text:
+    file: "clean_text.jinja"
+    description: "Template for cleaning markup and removing artifacts from Pandoc-converted HTML"
+    input_fields:
+      schema: "clean_text.CleanTextRequest"
+    output_format: "json"
+    output_fields:
+      schema: "clean_text.CleanTextResponse"
+
   # Summarization Templates
   summarize:
     file: "summarize.jinja"

--- a/marovi/modules/upload/__init__.py
+++ b/marovi/modules/upload/__init__.py
@@ -1,0 +1,5 @@
+"""Upload utilities for external services."""
+
+from .wiki import WikiUploader
+
+__all__ = ["WikiUploader"]

--- a/marovi/modules/upload/wiki.py
+++ b/marovi/modules/upload/wiki.py
@@ -1,0 +1,87 @@
+"""Utilities for uploading content to a MediaWiki instance."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+class WikiUploader:
+    """Simple client for uploading pages to a MediaWiki instance.
+
+    The uploader handles the basic login/token workflow required by the
+    MediaWiki API. Credentials are expected to be provided either directly or
+    through environment variables ``MAROVI_WIKI_USER`` and
+    ``MAROVI_WIKI_PASSWORD``.
+    """
+
+    def __init__(
+        self,
+        api_url: str,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+    ) -> None:
+        self.api_url = api_url
+        self.username = username or os.getenv("MAROVI_WIKI_USER")
+        self.password = password or os.getenv("MAROVI_WIKI_PASSWORD")
+        self.session = requests.Session()
+        self.csrf_token: Optional[str] = None
+
+    def _get_token(self, token_type: str) -> str:
+        """Fetch a token of ``token_type`` from the wiki."""
+        resp = self.session.get(
+            self.api_url,
+            params={"action": "query", "meta": "tokens", "type": token_type, "format": "json"},
+            timeout=30,
+        )
+        resp.raise_for_status()
+        return resp.json()["query"]["tokens"][f"{token_type}token"]
+
+    def login(self) -> None:
+        """Login to the wiki and store a CSRF token for later edits."""
+        if not self.username or not self.password:
+            raise ValueError("Wiki credentials are not provided")
+
+        login_token = self._get_token("login")
+        resp = self.session.post(
+            self.api_url,
+            data={
+                "action": "login",
+                "lgname": self.username,
+                "lgpassword": self.password,
+                "lgtoken": login_token,
+                "format": "json",
+            },
+            timeout=30,
+        )
+        resp.raise_for_status()
+        self.csrf_token = self._get_token("csrf")
+        logger.info("Authenticated with wiki API")
+
+    def upload_page(self, title: str, content: str, summary: str = "") -> None:
+        """Create or replace a wiki page with ``content``."""
+        if not self.csrf_token:
+            self.login()
+
+        resp = self.session.post(
+            self.api_url,
+            data={
+                "action": "edit",
+                "title": title,
+                "text": content,
+                "summary": summary,
+                "token": self.csrf_token,
+                "format": "json",
+            },
+            timeout=30,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        if "error" in data:
+            raise RuntimeError(f"Wiki upload failed: {data['error']}")
+        logger.info("Uploaded page '%s'", title)

--- a/marovi/pipelines/__init__.py
+++ b/marovi/pipelines/__init__.py
@@ -1,0 +1,5 @@
+"""Pipeline definitions for Marovi."""
+
+from .arxiv_to_wiki import ArxivToWikiPipeline
+
+__all__ = ["ArxivToWikiPipeline"]

--- a/marovi/pipelines/arxiv_to_wiki.py
+++ b/marovi/pipelines/arxiv_to_wiki.py
@@ -1,0 +1,126 @@
+"""Pipeline for converting ArXiv papers into wiki pages."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, List
+
+from marovi.modules.download import ArXivDownloader
+from marovi.modules.parsing.pandoc import PandocParser
+from marovi.modules.upload import WikiUploader
+from marovi.storage.document.paper_storage import PaperStorage
+from marovi.pipelines.core import Pipeline, PipelineStep
+from marovi.pipelines.context import PipelineContext
+from marovi.modules.steps.marovi_api import CleanTextStep
+
+logger = logging.getLogger(__name__)
+
+
+class DownloadArxivStep(PipelineStep[str, Dict[str, Any]]):
+    """Download an ArXiv paper and store its metadata."""
+
+    def __init__(self, storage: PaperStorage, step_id: str | None = None) -> None:
+        super().__init__(step_id=step_id or "download_arxiv")
+        self.downloader = ArXivDownloader(storage)
+
+    def process(self, inputs: List[str], context: PipelineContext) -> List[Dict[str, Any]]:
+        results = []
+        for arxiv_id in inputs:
+            paper_dir = self.downloader.download_document(arxiv_id)
+            if not paper_dir:
+                logger.warning("Skipping %s: download failed", arxiv_id)
+                continue
+            metadata_path = Path(paper_dir) / "metadata.json"
+            metadata: Dict[str, Any] = {}
+            if metadata_path.exists():
+                metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+            results.append({
+                "arxiv_id": arxiv_id,
+                "paper_dir": Path(paper_dir),
+                "metadata": metadata,
+            })
+        return results
+
+
+class HTMLToWikiStep(PipelineStep[Dict[str, Any], Dict[str, Any]]):
+    """Convert downloaded HTML to wiki markup using Pandoc."""
+
+    def process(self, inputs: List[Dict[str, Any]], context: PipelineContext) -> List[Dict[str, Any]]:
+        outputs: List[Dict[str, Any]] = []
+        for item in inputs:
+            arxiv_id = item["arxiv_id"]
+            paper_dir: Path = item["paper_dir"]
+            html_path = paper_dir / f"{arxiv_id}.html"
+            if not html_path.exists():
+                logger.warning("HTML file not found for %s", arxiv_id)
+                continue
+            html_content = html_path.read_text(encoding="utf-8")
+            parser = PandocParser(html_content)
+            wiki_dir = paper_dir / "wiki"
+            wiki_dir.mkdir(exist_ok=True)
+            wiki_output = wiki_dir / f"{arxiv_id}.wiki"
+            parser.convert_html_to_wiki(output_file=str(wiki_output))
+            wiki_text = wiki_output.read_text(encoding="utf-8")
+            item["wiki_path"] = wiki_output
+            item["wiki_text"] = wiki_text
+            outputs.append(item)
+        return outputs
+
+
+class CleanWikiStep(PipelineStep[Dict[str, Any], Dict[str, Any]]):
+    """Use LLM to clean the wiki markup."""
+
+    def __init__(self, provider: str = "openai", step_id: str | None = None) -> None:
+        super().__init__(batch_handling="inherent", step_id=step_id or "clean_wiki")
+        self.clean_step = CleanTextStep(format_value="wiki", provider=provider)
+
+    def process(self, inputs: List[Dict[str, Any]], context: PipelineContext) -> List[Dict[str, Any]]:
+        texts = [item["wiki_text"] for item in inputs]
+        cleaned_texts = self.clean_step.run_with_retries(texts, context)
+        outputs: List[Dict[str, Any]] = []
+        for item, cleaned in zip(inputs, cleaned_texts):
+            item["cleaned_text"] = cleaned
+            wiki_path = item.get("wiki_path")
+            if wiki_path:
+                Path(wiki_path).write_text(cleaned, encoding="utf-8")
+            outputs.append(item)
+        return outputs
+
+
+class UploadWikiStep(PipelineStep[Dict[str, Any], Dict[str, Any]]):
+    """Upload cleaned wiki text to a remote MediaWiki instance."""
+
+    def __init__(self, uploader: WikiUploader, step_id: str | None = None) -> None:
+        super().__init__(step_id=step_id or "upload_wiki")
+        self.uploader = uploader
+
+    def process(self, inputs: List[Dict[str, Any]], context: PipelineContext) -> List[Dict[str, Any]]:
+        outputs = []
+        for item in inputs:
+            title = item.get("metadata", {}).get("title") or item["arxiv_id"]
+            text = item.get("cleaned_text")
+            if not text:
+                logger.warning("No text to upload for %s", title)
+                continue
+            try:
+                self.uploader.upload_page(title, text)
+                item["uploaded"] = True
+            except Exception as exc:  # pylint: disable=broad-except
+                logger.error("Failed to upload %s: %s", title, exc)
+                item["uploaded"] = False
+                item["error"] = str(exc)
+            outputs.append(item)
+        return outputs
+
+
+class ArxivToWikiPipeline(Pipeline):
+    """Pipeline that downloads an ArXiv paper and publishes it to a wiki."""
+
+    def __init__(self, storage: PaperStorage, wiki_api_url: str, provider: str = "openai") -> None:
+        downloader = DownloadArxivStep(storage)
+        html_to_wiki = HTMLToWikiStep()
+        clean = CleanWikiStep(provider=provider)
+        uploader = UploadWikiStep(WikiUploader(wiki_api_url))
+        super().__init__(steps=[downloader, html_to_wiki, clean, uploader], name="arxiv_to_wiki")

--- a/marovi/tests/test_arxiv_to_wiki.py
+++ b/marovi/tests/test_arxiv_to_wiki.py
@@ -1,0 +1,182 @@
+import json
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Provide a minimal ``pydantic`` stub if the real library is unavailable
+# ---------------------------------------------------------------------------
+import sys
+import types
+
+try:  # pragma: no cover - executed only when pydantic is available
+    import pydantic as pydantic_stub  # type: ignore
+except Exception:  # pragma: no cover - executed when pydantic is missing
+    pydantic_stub = types.ModuleType("pydantic")
+
+    class BaseModel:  # minimal BaseModel placeholder
+        pass
+
+    def Field(default=None, **_kwargs):  # simple Field stub
+        return default
+
+    HttpUrl = str
+
+    pydantic_stub.BaseModel = BaseModel
+    pydantic_stub.Field = Field
+    pydantic_stub.HttpUrl = HttpUrl
+    def validator(*_args, **_kwargs):  # decorator stub
+        def _wrap(func):
+            return func
+        return _wrap
+    pydantic_stub.validator = validator
+    sys.modules.setdefault("pydantic", pydantic_stub)
+
+# Stub ``feedparser`` if missing
+try:  # pragma: no cover - executed only when feedparser is available
+    import feedparser  # type: ignore
+except Exception:  # pragma: no cover - executed when feedparser is missing
+    feedparser = types.ModuleType("feedparser")
+    def _parse(*_args, **_kwargs):
+        return types.SimpleNamespace(entries=[])
+    feedparser.parse = _parse  # type: ignore
+    sys.modules.setdefault("feedparser", feedparser)
+
+# Stub CleanTextStep to avoid importing heavy dependencies
+marovi_steps = types.ModuleType("marovi.modules.steps.marovi_api")
+class CleanTextStep:  # simple passthrough stub
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def run_with_retries(self, texts, _context):
+        return texts
+
+marovi_steps.CleanTextStep = CleanTextStep
+sys.modules.setdefault("marovi.modules.steps.marovi_api", marovi_steps)
+
+from marovi.modules.upload import WikiUploader
+from marovi.pipelines.arxiv_to_wiki import (
+    ArxivToWikiPipeline,
+    CleanWikiStep,
+    DownloadArxivStep,
+    HTMLToWikiStep,
+    UploadWikiStep,
+)
+from marovi.pipelines.context import PipelineContext
+from marovi.storage.document.paper_storage import PaperStorage
+
+
+def _mock_response(json_data):
+    resp = Mock()
+    resp.raise_for_status = Mock()
+    resp.json = Mock(return_value=json_data)
+    return resp
+
+
+def test_wiki_uploader_login_and_upload():
+    session = Mock()
+    session.get.side_effect = [
+        _mock_response({"query": {"tokens": {"logintoken": "LOGIN"}}}),
+        _mock_response({"query": {"tokens": {"csrftoken": "CSRF"}}}),
+    ]
+    session.post.side_effect = [
+        _mock_response({"login": {"result": "Success"}}),
+        _mock_response({"edit": {"result": "Success"}}),
+    ]
+    uploader = WikiUploader("https://wiki.example/api.php", "user", "pass")
+    uploader.session = session
+    uploader.upload_page("Title", "Content")
+    assert uploader.csrf_token == "CSRF"
+    session.post.assert_called_with(
+        "https://wiki.example/api.php",
+        data={
+            "action": "edit",
+            "title": "Title",
+            "text": "Content",
+            "summary": "",
+            "token": "CSRF",
+            "format": "json",
+        },
+        timeout=30,
+    )
+
+
+def test_wiki_uploader_error_on_upload():
+    session = Mock()
+    session.get.side_effect = [
+        _mock_response({"query": {"tokens": {"logintoken": "LOGIN"}}}),
+        _mock_response({"query": {"tokens": {"csrftoken": "CSRF"}}}),
+    ]
+    session.post.side_effect = [
+        _mock_response({"login": {"result": "Success"}}),
+        _mock_response({"error": {"code": "bad"}}),
+    ]
+    uploader = WikiUploader("https://wiki.example/api.php", "user", "pass")
+    uploader.session = session
+    with pytest.raises(RuntimeError):
+        uploader.upload_page("Title", "Content")
+
+
+def test_download_arxiv_step_reads_metadata(tmp_path):
+    storage = Mock(spec=PaperStorage)
+    downloader = Mock()
+    downloader.download_document.return_value = str(tmp_path)
+    (tmp_path / "metadata.json").write_text(json.dumps({"title": "Test"}))
+    step = DownloadArxivStep(storage)
+    step.downloader = downloader
+    outputs = step.process(["1234"], PipelineContext())
+    assert outputs[0]["metadata"]["title"] == "Test"
+
+
+def test_html_to_wiki_step_converts(tmp_path):
+    step = HTMLToWikiStep()
+    arxiv_id = "1234"
+    html_path = tmp_path / f"{arxiv_id}.html"
+    html_path.write_text("<p>Hello</p>")
+    item = {"arxiv_id": arxiv_id, "paper_dir": tmp_path, "metadata": {}}
+    with patch("marovi.pipelines.arxiv_to_wiki.PandocParser") as MockParser:
+        parser = Mock()
+        MockParser.return_value = parser
+        def fake_convert(output_file):
+            Path(output_file).write_text("converted")
+        parser.convert_html_to_wiki.side_effect = fake_convert
+        outputs = step.process([item], PipelineContext())
+    assert outputs[0]["wiki_text"] == "converted"
+
+
+def test_clean_wiki_step_runs_and_writes(tmp_path):
+    step = CleanWikiStep()
+    wiki_file = tmp_path / "file.wiki"
+    wiki_file.write_text("raw")
+    item = {"wiki_text": "raw", "wiki_path": wiki_file}
+    with patch.object(step.clean_step, "run_with_retries", return_value=["cleaned"]) as mock_run:
+        outputs = step.process([item], PipelineContext())
+    assert outputs[0]["cleaned_text"] == "cleaned"
+    assert wiki_file.read_text() == "cleaned"
+    mock_run.assert_called_once()
+
+
+def test_upload_wiki_step_calls_uploader():
+    uploader = Mock(spec=WikiUploader)
+    uploader.upload_page.return_value = None
+    step = UploadWikiStep(uploader)
+    item = {"arxiv_id": "123", "cleaned_text": "text", "metadata": {"title": "Title"}}
+    outputs = step.process([item], PipelineContext())
+    uploader.upload_page.assert_called_with("Title", "text")
+    assert outputs[0]["uploaded"] is True
+
+
+def test_arxiv_to_wiki_pipeline_runs(tmp_path):
+    storage = Mock(spec=PaperStorage)
+    pipeline = ArxivToWikiPipeline(storage, "https://wiki.example/api.php")
+    download_result = [{"arxiv_id": "1", "paper_dir": tmp_path, "metadata": {}}]
+    html_result = [{"arxiv_id": "1", "paper_dir": tmp_path, "metadata": {}, "wiki_text": "raw"}]
+    clean_result = [{"arxiv_id": "1", "paper_dir": tmp_path, "metadata": {}, "cleaned_text": "clean"}]
+    upload_result = [{"arxiv_id": "1", "uploaded": True}]
+    with patch.object(DownloadArxivStep, "process", return_value=download_result), \
+         patch.object(HTMLToWikiStep, "process", return_value=html_result), \
+         patch.object(CleanWikiStep, "process", return_value=clean_result), \
+         patch.object(UploadWikiStep, "process", return_value=upload_result):
+        outputs = pipeline.run(["1"], PipelineContext())
+    assert outputs[0]["uploaded"] is True

--- a/tutorials/arxiv_to_wiki.ipynb
+++ b/tutorials/arxiv_to_wiki.ipynb
@@ -1,0 +1,78 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# ArXiv to Wiki Conversion\n",
+    "This notebook demonstrates downloading an arXiv paper, converting the HTML to wiki markup using Pandoc, cleaning the markup with an LLM, and preparing it for upload."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from marovi.modules.download import ArXivDownloader\n",
+    "from marovi.modules.parsing.pandoc import PandocParser\n",
+    "from marovi.modules.steps.marovi_api import CleanTextStep\n",
+    "from marovi.storage.document.paper_storage import PaperStorage\n",
+    "from marovi.pipelines.context import PipelineContext\n",
+    "\n",
+    "storage = PaperStorage('papers')\n",
+    "arxiv_id = '2301.00001'\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "downloader = ArXivDownloader(storage)\n",
+    "paper_dir = downloader.download_document(arxiv_id)\n",
+    "paper_dir\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "html_path = paper_dir / f'{arxiv_id}.html'\n",
+    "html_text = html_path.read_text(encoding='utf-8')\n",
+    "parser = PandocParser(html_text)\n",
+    "wiki_path = paper_dir / 'wiki' / f'{arxiv_id}.wiki'\n",
+    "parser.convert_html_to_wiki(output_file=str(wiki_path))\n",
+    "wiki_path\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "raw_wiki = wiki_path.read_text(encoding='utf-8')\n",
+    "cleaner = CleanTextStep(format_value='wiki')\n",
+    "cleaned = cleaner.run_with_retries([raw_wiki], PipelineContext())[0]\n",
+    "print(cleaned[:500])\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- use standard `json` module in arXiv download step and type metadata
- add notebook demonstrating end-to-end arXiv to wiki conversion
- create unit tests for uploader, parsing, cleaning, and pipeline flow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68985ab6ec1883208f69a96056a2bc91